### PR TITLE
security: use SecureRandom for pairing codes + constant-time compare

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/auth/PairingManager.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/auth/PairingManager.kt
@@ -2,18 +2,28 @@ package com.hermesandroid.bridge.auth
 
 import android.content.Context
 import android.content.SharedPreferences
+import java.security.MessageDigest
+import java.security.SecureRandom
 
 /**
  * Manages the pairing code used to authenticate requests from the Hermes server.
  *
- * On first launch, generates a random 6-character alphanumeric code.
+ * On first launch, generates a cryptographically random 6-character alphanumeric code.
  * The code persists across app restarts. User can regenerate from the UI.
+ *
+ * Security:
+ *  - Uses java.security.SecureRandom (CSPRNG) instead of kotlin.random.Random
+ *    (which is a non-cryptographic PRNG and can be predicted from a few outputs).
+ *  - Token comparison uses MessageDigest.isEqual for constant-time equality
+ *    to mitigate timing side-channel attacks.
  */
 object PairingManager {
 
     private const val PREFS_NAME = "hermes_bridge_prefs"
     private const val KEY_PAIRING_CODE = "pairing_code"
     private const val CODE_LENGTH = 6
+
+    private val secureRandom = SecureRandom()
 
     private var prefs: SharedPreferences? = null
     private var cachedCode: String? = null
@@ -35,7 +45,11 @@ object PairingManager {
 
     fun regenerateCode(): String {
         val chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no 0/O/1/I to avoid confusion
-        val code = (1..CODE_LENGTH).map { chars.random() }.joinToString("")
+        val sb = StringBuilder(CODE_LENGTH)
+        repeat(CODE_LENGTH) {
+            sb.append(chars[secureRandom.nextInt(chars.length)])
+        }
+        val code = sb.toString()
         prefs?.edit()?.putString(KEY_PAIRING_CODE, code)?.apply()
         cachedCode = code
         return code
@@ -44,10 +58,18 @@ object PairingManager {
     /**
      * Validate an incoming request's Authorization header.
      * Expected format: "Bearer <code>"
+     *
+     * Uses MessageDigest.isEqual for constant-time comparison to avoid leaking
+     * the pairing code through response-time side channels.
      */
     fun validateToken(authHeader: String?): Boolean {
         if (authHeader == null) return false
         val token = authHeader.removePrefix("Bearer ").trim()
-        return token == getCode()
+        val expected = getCode()
+        if (expected.isEmpty()) return false
+        val a = token.toByteArray(Charsets.UTF_8)
+        val b = expected.toByteArray(Charsets.UTF_8)
+        if (a.size != b.size) return false
+        return MessageDigest.isEqual(a, b)
     }
 }

--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -24,6 +24,7 @@ Command JSON format:
 # to enable wss:// connections. Without these, the relay uses plaintext http.
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -351,7 +352,9 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
         )
 
     token = request.query.get("token", "")
-    if token.upper() != state.pairing_code.upper():
+    # Constant-time comparison to mitigate timing side-channel attacks that
+    # could otherwise leak the pairing code byte-by-byte.
+    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
         _auth_record_failure(remote_ip)
         logger.warning(
             "Phone WS rejected — bad token (got %s) from %s", token, remote_ip

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -24,6 +24,7 @@ Command JSON format:
 # to enable wss:// connections. Without these, the relay uses plaintext http.
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -350,7 +351,9 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
         )
 
     token = request.query.get("token", "")
-    if token.upper() != state.pairing_code.upper():
+    # Constant-time comparison to mitigate timing side-channel attacks that
+    # could otherwise leak the pairing code byte-by-byte.
+    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
         _auth_record_failure(remote_ip)
         logger.warning(
             "Phone WS rejected — bad token (got %s) from %s", token, remote_ip


### PR DESCRIPTION
## Summary

This PR fixes two related security weaknesses in the pairing-code path used to authenticate the Android bridge to the Hermes relay/server.

## 1. Predictable pairing codes (PairingManager.kt)

`PairingManager.regenerateCode()` previously used `chars.random()` (Kotlin's `kotlin.random.Random` / `java.util.Random`). That generator is a non-cryptographic LCG with only 48 bits of internal state — given a handful of observed outputs, an attacker can reconstruct the seed and predict every subsequent pairing code. Anyone who once paired with a device (or who can otherwise observe one code) could thus predict future regenerated codes and pair without authorization.

Fix: use `java.security.SecureRandom` (a CSPRNG) to draw indices into the alphabet. Same alphabet, same length, same UX — but unpredictable.

## 2. Timing side-channel in token comparison

Both the Kotlin `validateToken` and the Python relay (`tools/android_relay.py` and `hermes-android-plugin/android_relay.py`) compared the supplied token to the expected pairing code with the language's native `==` / string equality. Native string equality short-circuits on the first mismatching byte, so the response time leaks how many leading bytes are correct. A networked attacker that can measure response latency can therefore recover the 6-character code one byte at a time — far faster than brute-forcing the full keyspace, and well within reach even with the existing rate limiter (which only blocks after several full failures, not partial-byte probes).

Fix:
- Kotlin: compare with `java.security.MessageDigest.isEqual(a, b)` over UTF-8 bytes (constant-time).
- Python: compare with `hmac.compare_digest(...)` (constant-time).

## Files changed
- `hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/auth/PairingManager.kt`
- `tools/android_relay.py`
- `hermes-android-plugin/android_relay.py`

## Compatibility
No API or wire-format changes. Existing pairing codes continue to work; only newly regenerated codes use the stronger RNG. Comparison semantics are identical for matching inputs.