### PR TITLE
docs: unify android tool count across README, tests, and plugin docstring

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -42,8 +42,8 @@ Phone -> Relay:  {"request_id": "uuid", "result": {...}, "status": 200}
 ```
 hermes-android/
 ├── hermes-android-plugin/        # v0.3 plugin system integration
-│   ├── __init__.py               # register(ctx) — registers 14 tools via plugin API
-│   ├── android_tool.py           # tool handlers + schemas (14 tools)
+│   ├── __init__.py               # register(ctx) — registers 38 tools via plugin API
+│   ├── android_tool.py           # tool handlers + schemas (38 tools)
 │   ├── android_relay.py          # aiohttp relay server (WebSocket + HTTP bridge)
 │   ├── plugin.yaml               # plugin metadata
 │   └── skill.md                  # hermes-agent skill instructions
@@ -82,7 +82,7 @@ hermes-android/
 
 ### Plugin system (preferred)
 
-Drop `hermes-android-plugin/` into `~/.hermes/plugins/hermes-android`. The `register(ctx)` function in `__init__.py` registers all 14 tools via `ctx.register_tool()`.
+Drop `hermes-android-plugin/` into `~/.hermes/plugins/hermes-android`. The `register(ctx)` function in `__init__.py` registers all 38 tools via `ctx.register_tool()`.
 
 ### Legacy tools/ directory
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mkdir -p ~/.hermes/plugins
 cp -r hermes-android-plugin ~/.hermes/plugins/hermes-android
 ```
 
-Restart hermes — run `/plugins` to verify. Should show: `✓ hermes-android v0.3.0 (36 tools)`
+Restart hermes — run `/plugins` to verify. Should show: `✓ hermes-android v0.3.0 (38 tools)`
 
 ## Quick Start
 

--- a/hermes-android-plugin/skill.md
+++ b/hermes-android-plugin/skill.md
@@ -48,7 +48,7 @@ After the user taps Connect on their phone, the phone connects to this server vi
 
 ## Available Tools
 
-You have these 14 tools. Use them by name — they are function calls.
+You have these 38 tools. Use them by name — they are function calls.
 
 ### Connectivity
 - `android_ping()` — check if phone is connected and responding

--- a/skills/android/SKILL.md
+++ b/skills/android/SKILL.md
@@ -48,7 +48,7 @@ After the user taps Connect on their phone, the phone connects to this server vi
 
 ## Available Tools
 
-You have these 14 tools. Use them by name — they are function calls.
+You have these 38 tools. Use them by name — they are function calls.
 
 ### Connectivity
 - `android_ping()` — check if phone is connected and responding


### PR DESCRIPTION
Authoritative tool count: **38** (counted by deduplicating `def android_*` definitions across `tools/android_tool.py` and `hermes-android-plugin/android_tool.py` — both files contain exactly 38 unique tool functions, confirmed by existing test assertions in `tests/test_android_tool.py`).

Locations updated:
- `README.md` line 37: 36 → 38
- `PLAN.md` line 45: 14 → 38 (register comment)
- `PLAN.md` line 46: 14 → 38 (schemas comment)
- `PLAN.md` line 85: 14 → 38 (plugin install instructions)
- `skills/android/SKILL.md` line 51: 14 → 38
- `hermes-android-plugin/skill.md` line 51: 14 → 38