### PR TITLE
auto: mask pairing token in relay auth failure logs

### DIFF
--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -356,8 +356,9 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     # could otherwise leak the pairing code byte-by-byte.
     if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
         _auth_record_failure(remote_ip)
+        masked = (token[:2] + "****") if len(token) >= 2 else "****"
         logger.warning(
-            "Phone WS rejected — bad token (got %s) from %s", token, remote_ip
+            "Phone WS rejected — bad token (got %s) from %s", masked, remote_ip
         )
         raise web.HTTPForbidden(text="Invalid pairing code")
 

--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -342,6 +342,10 @@ def _auth_record_failure(ip: str) -> None:
 # ── WebSocket handler (phone side) ───────────────────────────────────────────
 
 
+def _mask_token(token: str) -> str:
+    return (token[:2] + "****") if len(token) >= 2 else "****"
+
+
 async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketResponse:
     # Rate limiting — check before token validation
     remote_ip = request.remote or "unknown"
@@ -356,9 +360,8 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     # could otherwise leak the pairing code byte-by-byte.
     if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
         _auth_record_failure(remote_ip)
-        masked = (token[:2] + "****") if len(token) >= 2 else "****"
         logger.warning(
-            "Phone WS rejected — bad token (got %s) from %s", masked, remote_ip
+            "Phone WS rejected — bad token (got %s) from %s", _mask_token(token), remote_ip
         )
         raise web.HTTPForbidden(text="Invalid pairing code")
 

--- a/tests/test_android_relay.py
+++ b/tests/test_android_relay.py
@@ -86,3 +86,33 @@ class TestRateLimiting:
         for _ in range(_AUTH_MAX_ATTEMPTS - 1):
             _auth_record_failure("1.2.3.4")
         assert not _auth_is_blocked("1.2.3.4")
+
+
+class TestTokenMasking:
+    """Verify that bad auth tokens are masked in log output, not logged in plaintext."""
+
+    def test_bad_token_logged_masked(self, caplog):
+        """When a bad WS auth token is provided, the log should show a masked version."""
+        import logging
+        from tools.android_relay import _RelayState
+
+        with caplog.at_level(logging.WARNING, logger="android_relay"):
+            # Simulate the masking logic directly
+            token = "SECRET123"
+            masked = (token[:2] + "****") if len(token) >= 2 else "****"
+            # Verify masking behavior
+            assert masked == "SE****"
+            assert token not in masked
+
+    def test_short_token_masked(self):
+        """Single-char tokens should be fully masked."""
+        token = "X"
+        masked = (token[:2] + "****") if len(token) >= 2 else "****"
+        assert masked == "****"
+        assert token not in masked
+
+    def test_empty_token_masked(self):
+        """Empty tokens should be fully masked."""
+        token = ""
+        masked = (token[:2] + "****") if len(token) >= 2 else "****"
+        assert masked == "****"

--- a/tests/test_android_relay.py
+++ b/tests/test_android_relay.py
@@ -13,6 +13,7 @@ from tools.android_relay import (
     _auth_blocked,
     _auth_failures,
     _AUTH_MAX_ATTEMPTS,
+    _mask_token,
 )
 
 
@@ -91,28 +92,15 @@ class TestRateLimiting:
 class TestTokenMasking:
     """Verify that bad auth tokens are masked in log output, not logged in plaintext."""
 
-    def test_bad_token_logged_masked(self, caplog):
-        """When a bad WS auth token is provided, the log should show a masked version."""
-        import logging
-        from tools.android_relay import _RelayState
-
-        with caplog.at_level(logging.WARNING, logger="android_relay"):
-            # Simulate the masking logic directly
-            token = "SECRET123"
-            masked = (token[:2] + "****") if len(token) >= 2 else "****"
-            # Verify masking behavior
-            assert masked == "SE****"
-            assert token not in masked
-
-    def test_short_token_masked(self):
-        """Single-char tokens should be fully masked."""
-        token = "X"
-        masked = (token[:2] + "****") if len(token) >= 2 else "****"
-        assert masked == "****"
+    def test_normal_token_masked(self):
+        token = "SECRET123"
+        masked = _mask_token(token)
+        assert masked == "SE****"
         assert token not in masked
 
-    def test_empty_token_masked(self):
-        """Empty tokens should be fully masked."""
-        token = ""
-        masked = (token[:2] + "****") if len(token) >= 2 else "****"
-        assert masked == "****"
+    def test_short_token_fully_masked(self):
+        assert _mask_token("X") == "****"
+        assert _mask_token("AB") == "AB****"
+
+    def test_empty_token_fully_masked(self):
+        assert _mask_token("") == "****"

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -360,8 +360,9 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     # could otherwise leak the pairing code byte-by-byte.
     if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
         _auth_record_failure(remote_ip)
+        masked = (token[:2] + "****") if len(token) >= 2 else "****"
         logger.warning(
-            "Phone WS rejected — bad token (got %s) from %s", token, remote_ip
+            "Phone WS rejected — bad token (got %s) from %s", masked, remote_ip
         )
         raise web.HTTPForbidden(text="Invalid pairing code")
 

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -346,6 +346,10 @@ def _auth_record_failure(ip: str) -> None:
 # ── WebSocket handler (phone side) ───────────────────────────────────────────
 
 
+def _mask_token(token: str) -> str:
+    return (token[:2] + "****") if len(token) >= 2 else "****"
+
+
 async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketResponse:
     # Rate limiting — check before token validation
     remote_ip = request.remote or "unknown"
@@ -360,9 +364,8 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     # could otherwise leak the pairing code byte-by-byte.
     if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
         _auth_record_failure(remote_ip)
-        masked = (token[:2] + "****") if len(token) >= 2 else "****"
         logger.warning(
-            "Phone WS rejected — bad token (got %s) from %s", masked, remote_ip
+            "Phone WS rejected — bad token (got %s) from %s", _mask_token(token), remote_ip
         )
         raise web.HTTPForbidden(text="Invalid pairing code")
 


### PR DESCRIPTION
## Summary
Masks the pairing token in log output when relay authentication fails, preventing sensitive credentials from appearing in plain-text logs.

## Changes
- Sanitize token in auth failure log messages in `android_relay.py` (plugin + tools)
- Add tests verifying token masking behavior

## Test plan
- [x] Unit tests pass (`test_android_relay.py`)