### PR TITLE
Fix Android 16 screen recording crash

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/MainActivity.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/MainActivity.kt
@@ -89,10 +89,11 @@ class MainActivity : Activity() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQUEST_CODE_SCREEN_RECORD) {
             if (resultCode == RESULT_OK && data != null) {
-                val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-                val projection = mpm.getMediaProjection(resultCode, data)
-                if (projection != null) {
-                    ScreenRecorder.setProjection(projection)
+                val service = BridgeAccessibilityService.instance
+                if (service == null) {
+                    Toast.makeText(this, "Enable Accessibility Service before screen recording", Toast.LENGTH_LONG).show()
+                } else {
+                    ScreenRecorder.setProjectionPermission(resultCode, data)
                     Toast.makeText(this, "Screen recording permission granted", Toast.LENGTH_SHORT).show()
                 }
             } else {
@@ -143,8 +144,14 @@ class MainActivity : Activity() {
 
         switchScreenRecord.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked && !ScreenRecorder.hasPermission()) {
-                val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-                startActivityForResult(mpm.createScreenCaptureIntent(), REQUEST_CODE_SCREEN_RECORD)
+                val service = BridgeAccessibilityService.instance
+                if (service == null) {
+                    Toast.makeText(this, "Enable Accessibility Service before screen recording", Toast.LENGTH_LONG).show()
+                    updatePermissionSwitches()
+                } else {
+                    val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+                    startActivityForResult(mpm.createScreenCaptureIntent(), REQUEST_CODE_SCREEN_RECORD)
+                }
             }
         }
     }

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
@@ -114,7 +114,11 @@ object RelayClient {
             override fun onOpen(webSocket: WebSocket, response: Response) {
                 Log.i(TAG, "WebSocket connected to $wsUrl")
                 isConnected = true
-                BridgeAccessibilityService.instance?.startForeground()
+                try {
+                    BridgeAccessibilityService.instance?.startForeground()
+                } catch (e: SecurityException) {
+                    Log.w(TAG, "Could not promote bridge service to foreground", e)
+                }
                 notifyStatus(true, "Connected to $serverUrl")
             }
 

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
@@ -1,6 +1,7 @@
 package com.hermesandroid.bridge.media
 
 import android.content.Context
+import android.content.Intent
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
 import android.media.MediaRecorder
@@ -13,17 +14,26 @@ import com.hermesandroid.bridge.service.BridgeAccessibilityService
 import java.io.File
 
 object ScreenRecorder {
-    private var projection: MediaProjection? = null
+    private const val NO_PERMISSION_MESSAGE =
+        "No MediaProjection. Grant Screen Recording in the app before each capture on Android 16."
+
+    private var projectionResultCode: Int? = null
+    private var projectionData: Intent? = null
     private var recorder: MediaRecorder? = null
     private var virtualDisplay: VirtualDisplay? = null
     private val handlerThread = HandlerThread("ScreenRecorder").apply { start() }
     private val handler = Handler(handlerThread.looper)
 
-    fun hasPermission(): Boolean = projection != null
+    fun hasPermission(): Boolean = projectionData != null
 
-    fun setProjection(p: MediaProjection) {
-        projection?.stop()
-        projection = p
+    fun setProjectionPermission(resultCode: Int, data: Intent) {
+        projectionResultCode = resultCode
+        projectionData = Intent(data)
+    }
+
+    private fun clearProjectionPermission() {
+        projectionResultCode = null
+        projectionData = null
     }
 
     /**
@@ -35,15 +45,30 @@ object ScreenRecorder {
     fun record(durationMs: Long = 5000): Map<String, Any?> {
         val service = BridgeAccessibilityService.instance
             ?: return mapOf("success" to false, "message" to "Accessibility service not running")
-        val proj = projection
-            ?: return mapOf("success" to false, "message" to "No MediaProjection. Tap 'Grant Screen Recording' in the app first.")
+        val resultCode = projectionResultCode
+            ?: return mapOf("success" to false, "message" to NO_PERMISSION_MESSAGE)
+        val resultData = projectionData
+            ?: return mapOf("success" to false, "message" to NO_PERMISSION_MESSAGE)
 
         val latch = java.util.concurrent.CountDownLatch(1)
         val resultHolder = arrayOf<Map<String, Any?>?>(null)
 
         handler.post {
             var outputFile: File? = null
+            var projection: MediaProjection? = null
+            var projectionCallback: MediaProjection.Callback? = null
             try {
+                service.startForeground(includeMediaProjection = true)
+                val mpm = service.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+                projection = mpm.getMediaProjection(resultCode, resultData)
+                    ?: throw IllegalStateException("MediaProjection permission token was not accepted")
+                projectionCallback = object : MediaProjection.Callback() {
+                    override fun onStop() {
+                        cleanupRecording()
+                    }
+                }
+                projection.registerCallback(projectionCallback, handler)
+
                 outputFile = File(service.cacheDir, "screen_record_${System.currentTimeMillis()}.mp4")
                 val metrics = service.resources.displayMetrics
                 val width = metrics.widthPixels
@@ -62,7 +87,7 @@ object ScreenRecorder {
                 }
                 recorder = mr
 
-                val vd = proj.createVirtualDisplay(
+                val vd = projection.createVirtualDisplay(
                     "ScreenRecorder", width, height, density,
                     DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
                     mr.surface, null, handler
@@ -97,13 +122,18 @@ object ScreenRecorder {
                     )
                 )
             } catch (e: Exception) {
-                try { recorder?.release() } catch (_: Exception) {}
-                try { virtualDisplay?.release() } catch (_: Exception) {}
-                recorder = null
-                virtualDisplay = null
+                cleanupRecording()
                 outputFile?.delete()
+                if (e is SecurityException || e is IllegalStateException) {
+                    clearProjectionPermission()
+                }
                 resultHolder[0] = mapOf("success" to false, "message" to "Recording failed: ${e.javaClass.simpleName}: ${e.message}")
             } finally {
+                try {
+                    if (projectionCallback != null) projection?.unregisterCallback(projectionCallback)
+                } catch (_: Exception) {}
+                try { projection?.stop() } catch (_: Exception) {}
+                if (projection != null) clearProjectionPermission()
                 latch.countDown()
             }
         }
@@ -113,7 +143,15 @@ object ScreenRecorder {
         return resultHolder[0] ?: mapOf("success" to false, "message" to "Recording timed out")
     }
 
+    private fun cleanupRecording() {
+        try { recorder?.release() } catch (_: Exception) {}
+        try { virtualDisplay?.release() } catch (_: Exception) {}
+        recorder = null
+        virtualDisplay = null
+    }
+
     fun release() {
+        cleanupRecording()
         handlerThread.quitSafely()
     }
 }

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeAccessibilityService.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeAccessibilityService.kt
@@ -4,11 +4,14 @@ import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.pm.ServiceInfo
 import android.os.Build
+import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 
 class BridgeAccessibilityService : AccessibilityService() {
 
     companion object {
+        private const val TAG = "BridgeA11yService"
+
         @Volatile
         var instance: BridgeAccessibilityService? = null
             private set
@@ -38,9 +41,22 @@ class BridgeAccessibilityService : AccessibilityService() {
     }
 
     private var isForeground = false
+    private var foregroundTypes = 0
 
-    fun startForeground() {
-        if (isForeground) return
+    fun startForeground(includeMediaProjection: Boolean = false) {
+        val requestedTypes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE or
+                if (includeMediaProjection) {
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+                } else {
+                    0
+                }
+        } else {
+            0
+        }
+
+        if (isForeground && (foregroundTypes and requestedTypes) == requestedTypes) return
+
         val channelId = "hermes_bridge_channel"
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = android.app.NotificationChannel(
@@ -70,13 +86,13 @@ class BridgeAccessibilityService : AccessibilityService() {
                 .build()
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(1, notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE or
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION)
+            Log.i(TAG, "Starting foreground service with types=$requestedTypes")
+            startForeground(1, notification, requestedTypes)
         } else {
             startForeground(1, notification)
         }
         isForeground = true
+        foregroundTypes = requestedTypes
     }
 
     fun stopForeground() {
@@ -88,6 +104,7 @@ class BridgeAccessibilityService : AccessibilityService() {
             stopForeground(true)
         }
         isForeground = false
+        foregroundTypes = 0
     }
 
     override fun onInterrupt() {


### PR DESCRIPTION
## Summary
- Fix Android 16 MediaProjection crashes in the Hermes Bridge screen recording flow.
- Start the foreground service in normal bridge mode for relay connection, and only request the `mediaProjection` foreground service type immediately before consuming a granted capture token.
- Treat Android 16 capture tokens as single-use: store the grant result, create the projection at recording time, clean up recording resources, and clear the token after use or rejection.
- Keep relay foreground promotion from taking down the WebSocket connection if Android rejects foreground service promotion.

## Root Cause
On Android 16 / SDK 36, `MediaProjectionManager.getMediaProjection(...)` requires the app to already be running a foreground service of type `mediaProjection`. Starting that foreground service too early also fails because Android has not granted capture permission yet. In addition, Android rejects reusing the same MediaProjection result token for multiple capture sessions.

## Validation
Tested on a Pixel 9 running Android 16 / SDK 36 with Hermes relay over local Wi-Fi:
- `./gradlew.bat assembleDebug --stacktrace`
- installed the patched debug APK via ADB
- granted Hermes Bridge Accessibility, overlay, notification listener, and screen recording
- verified relay `/ping` reports `authenticated: true` and `accessibilityService: true`
- verified Hermes plugin calls: `android_ping`, `android_read_screen`, `android_get_apps`, `android_screenshot`
- verified `android_screen_record(duration_ms=1000)` returns an MP4 media artifact
- checked logcat crash buffer after grant and recording; no `FATAL EXCEPTION`

## Notes
Android 16 appears to enforce one capture per screen-recording grant. After a recording consumes the token, the bridge now clears it so the next capture prompts for a fresh grant instead of crashing or surfacing a token-reuse `SecurityException`.