### PR TITLE
[codex] 複数Android端末のrelay管理に対応

### DIFF
--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -514,7 +514,7 @@ _RESPONSE_TIMEOUT = 30  # seconds
 
 def _device_name(state: _RelayState, token: str) -> str:
     for alias, alias_token in state.device_aliases.items():
-        if alias_token == token:
+        if alias_token == token and _normalize_token(alias) == token:
             return alias
     return token
 

--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -48,7 +48,11 @@ class _RelayState:
     """Holds all mutable state for one running relay instance."""
 
     def __init__(self, pairing_code: str, port: int):
-        self.pairing_code: str = pairing_code
+        self.pairing_codes: set[str] = _parse_pairing_codes(pairing_code)
+        self.device_aliases: dict[str, str] = _parse_device_aliases()
+        self.default_device: Optional[str] = _normalize_token(
+            os.getenv("ANDROID_DEFAULT_DEVICE", "")
+        )
         self.port: int = port
 
         # asyncio loop running in the background thread
@@ -60,12 +64,12 @@ class _RelayState:
         self.runner: Optional[web.AppRunner] = None
         self.site: Optional[web.TCPSite] = None
 
-        # The single connected phone WebSocket (or None)
-        self.phone_ws: Optional[web.WebSocketResponse] = None
+        # Connected phone WebSockets keyed by pairing token.
+        self.phone_ws: dict[str, web.WebSocketResponse] = {}
         self.phone_ws_lock = asyncio.Lock()  # created lazily in the event loop
 
-        # Pending requests: request_id -> asyncio.Future
-        self.pending: dict[str, asyncio.Future] = {}
+        # Pending requests: request_id -> (asyncio.Future, token)
+        self.pending: dict[str, tuple[asyncio.Future, str]] = {}
         self.pending_lock: Optional[asyncio.Lock] = None  # created lazily
 
         # Shutdown event
@@ -73,6 +77,41 @@ class _RelayState:
 
 
 # ── Public API (called from sync code) ────────────────────────────────────────
+
+
+def _normalize_token(token: str) -> str:
+    return token.strip().upper()
+
+
+def _parse_pairing_codes(pairing_code: str) -> set[str]:
+    raw_codes = [pairing_code, os.getenv("ANDROID_BRIDGE_TOKENS", "")]
+    codes: set[str] = set()
+    for raw in raw_codes:
+        for code in raw.replace(";", ",").split(","):
+            normalized = _normalize_token(code)
+            if normalized:
+                codes.add(normalized)
+    if not codes:
+        raise ValueError("At least one pairing code is required")
+    return codes
+
+
+def _parse_device_aliases() -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    raw = os.getenv("ANDROID_BRIDGE_DEVICES", "")
+    for entry in raw.replace(";", ",").split(","):
+        if "=" not in entry:
+            continue
+        alias, token = entry.split("=", 1)
+        normalized_alias = alias.strip()
+        normalized_token = _normalize_token(token)
+        if normalized_alias and normalized_token:
+            aliases[normalized_alias] = normalized_token
+    return aliases
+
+
+def _mask_token(token: str) -> str:
+    return (token[:2] + "****") if len(token) >= 2 else "****"
 
 
 def start_relay(pairing_code: str, port: int = 0) -> None:
@@ -134,8 +173,7 @@ def is_phone_connected() -> bool:
         s = _relay_instance
         if s is None:
             return False
-        ws = s.phone_ws
-        return ws is not None and not ws.closed
+        return any(not ws.closed for ws in s.phone_ws.values())
 
 
 def get_relay_url() -> str:
@@ -150,7 +188,7 @@ def set_pairing_code(code: str) -> None:
     with _relay_lock:
         s = _relay_instance
         if s is not None:
-            s.pairing_code = code
+            s.pairing_codes = _parse_pairing_codes(code)
             logger.info("Pairing code updated")
 
 
@@ -197,51 +235,56 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
 
     # WebSocket endpoint
     app.router.add_get("/ws", lambda req: _handle_ws(req, state))
+    app.router.add_get("/devices", lambda req: _handle_devices(req, state))
 
-    # HTTP bridge endpoints (GET)
-    for path in ("/ping", "/screen", "/screenshot", "/apps", "/current_app"):
-        app.router.add_get(path, lambda req, p=path: _handle_http(req, state, p))
+    # HTTP bridge endpoints — method per path
+    ROUTES = {
+        # GET-only
+        "/ping":          "GET",
+        "/screen":        "GET",
+        "/screenshot":    "GET",
+        "/apps":          "GET",
+        "/current_app":   "GET",
+        "/notifications": "GET",
+        "/contacts":      "GET",
+        "/events":        "GET",
+        "/screen_hash":   "GET",
+        "/location":      "GET",
+        "/widgets":       "GET",
+        # POST-only
+        "/tap":           "POST",
+        "/tap_text":      "POST",
+        "/type":          "POST",
+        "/swipe":         "POST",
+        "/open_app":      "POST",
+        "/press_key":     "POST",
+        "/scroll":        "POST",
+        "/wait":          "POST",
+        "/long_press":    "POST",
+        "/drag":          "POST",
+        "/describe_node": "POST",
+        "/find_nodes":    "POST",
+        "/diff_screen":   "POST",
+        "/pinch":         "POST",
+        "/send_sms":      "POST",
+        "/call":          "POST",
+        "/media":         "POST",
+        "/intent":        "POST",
+        "/broadcast":     "POST",
+        "/speak":         "POST",
+        "/stop_speaking": "POST",
+        "/screen_record": "POST",
+        "/events/stream": "POST",
+        # READ + WRITE
+        "/clipboard":     "BOTH",
+    }
 
-    # HTTP bridge endpoints (POST)
-    for path in (
-        "/tap",
-        "/tap_text",
-        "/type",
-        "/swipe",
-        "/open_app",
-        "/press_key",
-        "/scroll",
-        "/wait",
-        "/long_press",
-        "/drag",
-        "/describe_node",
-        "/find_nodes",
-        "/diff_screen",
-        "/pinch",
-        "/send_sms",
-        "/call",
-        "/media",
-        "/intent",
-        "/broadcast",
-        "/speak",
-        "/stop_speaking",
-        "/screen_record",
-        "/events/stream",
-        "/clipboard",
-    ):
-        app.router.add_post(path, lambda req, p=path: _handle_http(req, state, p))
-
-    # HTTP bridge endpoints (GET) — additional
-    for path in (
-        "/clipboard",
-        "/notifications",
-        "/contacts",
-        "/events",
-        "/screen_hash",
-        "/location",
-        "/widgets",
-    ):
-        app.router.add_get(path, lambda req, p=path: _handle_http(req, state, p))
+    for path, method in ROUTES.items():
+        handler = lambda req, p=path: _handle_http(req, state, p)
+        if method in ("GET", "BOTH"):
+            app.router.add_get(path, handler)
+        if method in ("POST", "BOTH"):
+            app.router.add_post(path, handler)
 
     runner = web.AppRunner(app)
     state.runner = runner
@@ -260,7 +303,7 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
     await state.shutdown_event.wait()
 
     # Cleanup
-    await _cleanup_phone(state, reason="relay shutdown")
+    await _cleanup_all_phones(state, reason="relay shutdown")
     await runner.cleanup()
     logger.info("Relay server cleaned up")
 
@@ -355,29 +398,32 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
             text="Too many failed authentication attempts. Try again later."
         )
 
-    token = request.query.get("token", "")
+    token = _normalize_token(request.query.get("token", ""))
     # Constant-time comparison to mitigate timing side-channel attacks that
     # could otherwise leak the pairing code byte-by-byte.
-    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
+    if not any(hmac.compare_digest(token, code) for code in state.pairing_codes):
         _auth_record_failure(remote_ip)
         logger.warning(
-            "Phone WS rejected — bad token (got %s) from %s", _mask_token(token), remote_ip
+            "Phone WS rejected — bad token (got %s) from %s",
+            _mask_token(token),
+            remote_ip,
         )
         raise web.HTTPForbidden(text="Invalid pairing code")
 
     ws = web.WebSocketResponse(heartbeat=15.0)
     await ws.prepare(request)
 
-    # Only one phone at a time — kick previous if any
+    # Keep one connection per token. A reconnect replaces only that device.
     async with state.phone_ws_lock:
-        if state.phone_ws is not None and not state.phone_ws.closed:
-            logger.info("Replacing previous phone connection")
-            await state.phone_ws.close(
+        existing = state.phone_ws.get(token)
+        if existing is not None and not existing.closed:
+            logger.info("Replacing previous phone connection for token=%s", _mask_token(token))
+            await existing.close(
                 code=aiohttp.WSCloseCode.GOING_AWAY, message=b"replaced"
             )
-        state.phone_ws = ws
+        state.phone_ws[token] = ws
 
-    logger.info("Phone connected from %s", request.remote)
+    logger.info("Phone connected from %s token=%s", request.remote, _mask_token(token))
 
     try:
         async for msg in ws:
@@ -387,7 +433,7 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
                 logger.error("Phone WS error: %s", ws.exception())
                 break
     finally:
-        await _cleanup_phone(state, reason="phone disconnected")
+        await _cleanup_phone(state, token, ws, reason="phone disconnected")
 
     return ws
 
@@ -406,31 +452,45 @@ async def _on_phone_message(state: _RelayState, raw: str) -> None:
         return
 
     async with state.pending_lock:
-        future = state.pending.pop(request_id, None)
+        pending = state.pending.pop(request_id, None)
 
-    if future is None:
+    if pending is None:
         logger.debug(
             "No pending future for request_id=%s (possibly timed out)", request_id
         )
         return
 
+    future, _token = pending
     if not future.done():
         future.set_result(data)
 
 
-async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
-    """Clean up phone connection and cancel all pending requests."""
+async def _cleanup_phone(
+    state: _RelayState,
+    token: str,
+    ws: Optional[web.WebSocketResponse] = None,
+    reason: str = "",
+) -> None:
+    """Clean up one phone connection and cancel pending requests for that token."""
     async with state.phone_ws_lock:
-        ws = state.phone_ws
-        state.phone_ws = None
+        current = state.phone_ws.get(token)
+        if ws is None:
+            ws = current
+        if current is ws:
+            state.phone_ws.pop(token, None)
 
     if ws is not None and not ws.closed:
         await ws.close()
 
-    # Fail all pending futures
+    # Fail pending futures for this device only.
     async with state.pending_lock:
-        pending = dict(state.pending)
-        state.pending.clear()
+        pending = {
+            rid: fut
+            for rid, (fut, pending_token) in state.pending.items()
+            if pending_token == token
+        }
+        for rid in pending:
+            state.pending.pop(rid, None)
 
     for rid, fut in pending.items():
         if not fut.done():
@@ -440,21 +500,114 @@ async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
         logger.info("Cancelled %d pending requests (%s)", len(pending), reason)
 
 
+async def _cleanup_all_phones(state: _RelayState, reason: str = "") -> None:
+    async with state.phone_ws_lock:
+        phones = list(state.phone_ws.items())
+    for token, ws in phones:
+        await _cleanup_phone(state, token, ws, reason=reason)
+
+
 # ── HTTP handler (tool side) ─────────────────────────────────────────────────
 
 _RESPONSE_TIMEOUT = 30  # seconds
+
+
+def _device_name(state: _RelayState, token: str) -> str:
+    for alias, alias_token in state.device_aliases.items():
+        if alias_token == token:
+            return alias
+    return token
+
+
+def _resolve_requested_token(
+    state: _RelayState,
+    request: web.Request,
+    body: Optional[dict] = None,
+) -> tuple[Optional[str], Optional[web.Response]]:
+    requested = (
+        request.query.get("device")
+        or request.query.get("token")
+        or request.query.get("target_device")
+        or request.headers.get("X-Android-Device")
+    )
+    if body:
+        requested = requested or body.pop("device", None) or body.pop("target_device", None)
+
+    if requested:
+        requested_text = str(requested).strip()
+        token = state.device_aliases.get(requested_text, _normalize_token(requested_text))
+        if token not in state.pairing_codes:
+            return None, web.json_response(
+                {"error": f"Unknown Android device '{requested_text}'"},
+                status=404,
+            )
+        return token, None
+
+    if state.default_device:
+        token = state.device_aliases.get(state.default_device, state.default_device)
+        if token in state.pairing_codes:
+            return token, None
+
+    connected = [token for token, ws in state.phone_ws.items() if not ws.closed]
+    if len(connected) == 1:
+        return connected[0], None
+
+    if not connected:
+        return None, web.json_response(
+            {
+                "error": "No phone connected. Open the Hermes app on your phone and connect."
+            },
+            status=503,
+        )
+
+    return None, web.json_response(
+        {
+            "error": "Multiple phones are connected. Specify device.",
+            "devices": [_device_name(state, token) for token in connected],
+        },
+        status=400,
+    )
+
+
+async def _handle_devices(request: web.Request, state: _RelayState) -> web.Response:
+    """Return configured devices and their connection state."""
+    async with state.phone_ws_lock:
+        connected = {token for token, ws in state.phone_ws.items() if not ws.closed}
+
+    devices = []
+    for token in sorted(state.pairing_codes):
+        devices.append(
+            {
+                "device": _device_name(state, token),
+                "token": _mask_token(token),
+                "connected": token in connected,
+                "default": token == state.default_device,
+            }
+        )
+    return web.json_response({"devices": devices})
 
 
 async def _handle_http(
     request: web.Request, state: _RelayState, path: str
 ) -> web.Response:
     """Forward an HTTP request from a tool to the phone over WebSocket."""
+    body = {}
+    if request.method == "POST":
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+
+    token, error_response = _resolve_requested_token(state, request, body)
+    if error_response is not None:
+        return error_response
+
     async with state.phone_ws_lock:
-        ws = state.phone_ws
+        ws = state.phone_ws.get(token) if token else None
         if ws is None or ws.closed:
             return web.json_response(
                 {
-                    "error": "No phone connected. Open the Hermes app on your phone and connect."
+                    "error": f"Android device '{_device_name(state, token or '')}' is not connected."
                 },
                 status=503,
             )
@@ -463,13 +616,8 @@ async def _handle_http(
     request_id = str(uuid.uuid4())
     method = request.method  # GET or POST
     params = dict(request.query)
-
-    body = {}
-    if method == "POST":
-        try:
-            body = await request.json()
-        except Exception:
-            body = {}
+    for key in ("device", "token", "target_device"):
+        params.pop(key, None)
 
     command = {
         "request_id": request_id,
@@ -483,7 +631,7 @@ async def _handle_http(
     # Register a future *before* sending so we never miss the reply
     future = state.loop.create_future()
     async with state.pending_lock:
-        state.pending[request_id] = future
+        state.pending[request_id] = (future, token)
 
     try:
         await ws.send_json(command)

--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -519,6 +519,15 @@ def _device_name(state: _RelayState, token: str) -> str:
     return token
 
 
+def _device_aliases(state: _RelayState, token: str) -> list[str]:
+    aliases = [
+        alias for alias, alias_token in state.device_aliases.items() if alias_token == token
+    ]
+    if token not in aliases:
+        aliases.append(token)
+    return aliases
+
+
 def _resolve_requested_token(
     state: _RelayState,
     request: web.Request,
@@ -579,6 +588,7 @@ async def _handle_devices(request: web.Request, state: _RelayState) -> web.Respo
         devices.append(
             {
                 "device": _device_name(state, token),
+                "aliases": _device_aliases(state, token),
                 "token": _mask_token(token),
                 "connected": token in connected,
                 "default": token == state.default_device,

--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -40,14 +40,16 @@ def _bridge_token() -> Optional[str]:
 _CURRENT_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "android_device", default=None
 )
-_ACTIVE_DEVICE: Optional[str] = None
+_ACTIVE_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "android_active_device", default=None
+)
 
 
 def _selected_device(device: Optional[str] = None) -> Optional[str]:
     return (
         device
         or _CURRENT_DEVICE.get()
-        or _ACTIVE_DEVICE
+        or _ACTIVE_DEVICE.get()
         or os.getenv("ANDROID_DEFAULT_DEVICE")
     )
 
@@ -154,9 +156,8 @@ def android_devices() -> str:
 def android_select_device(device: str) -> str:
     """
     Select the Android device that subsequent android_* tool calls should target.
-    Use a device alias from android_devices(), such as 'old' or 'lrw2u7'.
+    Use a device alias from android_devices(), such as 'phone-a' or 'lrw2u7'.
     """
-    global _ACTIVE_DEVICE
     try:
         requested = str(device).strip()
         if not requested:
@@ -178,13 +179,14 @@ def android_select_device(device: str) -> str:
                             "devices": devices,
                         }
                     )
-                _ACTIVE_DEVICE = item.get("device") or requested
+                _ACTIVE_DEVICE.set(requested)
                 return json.dumps(
                     {
                         "status": "ok",
-                        "active_device": _ACTIVE_DEVICE,
+                        "active_device": requested,
+                        "matched_device": item.get("device"),
                         "message": (
-                            f"Selected Android device '{_ACTIVE_DEVICE}'. "
+                            f"Selected Android device '{requested}'. "
                             "Subsequent android_* calls will target it unless a device argument is provided."
                         ),
                         "devices": devices,
@@ -952,7 +954,7 @@ _SCHEMAS = {
             "properties": {
                 "device": {
                     "type": "string",
-                    "description": "Device alias from android_devices, such as old, new, lrw2u7, or emdmfu.",
+                    "description": "Device alias from android_devices, such as phone-a, work, lrw2u7, or emdmfu.",
                 }
             },
             "required": ["device"],
@@ -1549,45 +1551,53 @@ def _with_target_device(args: dict, handler):
     finally:
         _CURRENT_DEVICE.reset(token)
 
+def _make_handler(func, *, target_device: bool = True, pass_args: bool = True):
+    def _call(call_args: dict):
+        return func(**call_args) if pass_args else func()
+
+    if not target_device:
+        return lambda args, **kw: _call(dict(args or {}))
+    return lambda args, **kw: _with_target_device(args, _call)
+
 _HANDLERS = {
-    "android_ping": lambda args, **kw: _with_target_device(args, lambda _args: android_ping()),
-    "android_devices": lambda args, **kw: android_devices(),
-    "android_select_device": lambda args, **kw: android_select_device(**args),
-    "android_read_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_read_screen(**call_args)),
-    "android_tap": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap(**call_args)),
-    "android_tap_text": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap_text(**call_args)),
-    "android_type": lambda args, **kw: _with_target_device(args, lambda call_args: android_type(**call_args)),
-    "android_swipe": lambda args, **kw: _with_target_device(args, lambda call_args: android_swipe(**call_args)),
-    "android_open_app": lambda args, **kw: _with_target_device(args, lambda call_args: android_open_app(**call_args)),
-    "android_press_key": lambda args, **kw: _with_target_device(args, lambda call_args: android_press_key(**call_args)),
-    "android_screenshot": lambda args, **kw: _with_target_device(args, lambda _args: android_screenshot()),
-    "android_scroll": lambda args, **kw: _with_target_device(args, lambda call_args: android_scroll(**call_args)),
-    "android_wait": lambda args, **kw: _with_target_device(args, lambda call_args: android_wait(**call_args)),
-    "android_get_apps": lambda args, **kw: _with_target_device(args, lambda _args: android_get_apps()),
-    "android_current_app": lambda args, **kw: _with_target_device(args, lambda _args: android_current_app()),
-    "android_setup": lambda args, **kw: android_setup(**args),
-    "android_clipboard_read": lambda args, **kw: _with_target_device(args, lambda _args: android_clipboard_read()),
-    "android_clipboard_write": lambda args, **kw: _with_target_device(args, lambda call_args: android_clipboard_write(**call_args)),
-    "android_notifications": lambda args, **kw: _with_target_device(args, lambda call_args: android_notifications(**call_args)),
-    "android_long_press": lambda args, **kw: _with_target_device(args, lambda call_args: android_long_press(**call_args)),
-    "android_drag": lambda args, **kw: _with_target_device(args, lambda call_args: android_drag(**call_args)),
-    "android_describe_node": lambda args, **kw: _with_target_device(args, lambda call_args: android_describe_node(**call_args)),
-    "android_screen_hash": lambda args, **kw: _with_target_device(args, lambda _args: android_screen_hash()),
-    "android_macro": lambda args, **kw: _with_target_device(args, lambda call_args: android_macro(**call_args)),
-    "android_location": lambda args, **kw: _with_target_device(args, lambda _args: android_location()),
-    "android_send_sms": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_sms(**call_args)),
-    "android_call": lambda args, **kw: _with_target_device(args, lambda call_args: android_call(**call_args)),
-    "android_speak": lambda args, **kw: _with_target_device(args, lambda call_args: android_speak(**call_args)),
-    "android_speak_stop": lambda args, **kw: _with_target_device(args, lambda _args: android_speak_stop()),
-    "android_events": lambda args, **kw: _with_target_device(args, lambda call_args: android_events(**call_args)),
-    "android_event_stream": lambda args, **kw: _with_target_device(args, lambda call_args: android_event_stream(**call_args)),
-    "android_screen_record": lambda args, **kw: _with_target_device(args, lambda call_args: android_screen_record(**call_args)),
-    "android_read_widgets": lambda args, **kw: _with_target_device(args, lambda _args: android_read_widgets()),
-    "android_find_nodes": lambda args, **kw: _with_target_device(args, lambda call_args: android_find_nodes(**call_args)),
-    "android_diff_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_diff_screen(**call_args)),
-    "android_pinch": lambda args, **kw: _with_target_device(args, lambda call_args: android_pinch(**call_args)),
-    "android_media": lambda args, **kw: _with_target_device(args, lambda call_args: android_media(**call_args)),
-    "android_search_contacts": lambda args, **kw: _with_target_device(args, lambda call_args: android_search_contacts(**call_args)),
-    "android_send_intent": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_intent(**call_args)),
-    "android_broadcast": lambda args, **kw: _with_target_device(args, lambda call_args: android_broadcast(**call_args)),
+    "android_ping": _make_handler(android_ping, pass_args=False),
+    "android_devices": _make_handler(android_devices, target_device=False, pass_args=False),
+    "android_select_device": _make_handler(android_select_device, target_device=False),
+    "android_read_screen": _make_handler(android_read_screen),
+    "android_tap": _make_handler(android_tap),
+    "android_tap_text": _make_handler(android_tap_text),
+    "android_type": _make_handler(android_type),
+    "android_swipe": _make_handler(android_swipe),
+    "android_open_app": _make_handler(android_open_app),
+    "android_press_key": _make_handler(android_press_key),
+    "android_screenshot": _make_handler(android_screenshot, pass_args=False),
+    "android_scroll": _make_handler(android_scroll),
+    "android_wait": _make_handler(android_wait),
+    "android_get_apps": _make_handler(android_get_apps, pass_args=False),
+    "android_current_app": _make_handler(android_current_app, pass_args=False),
+    "android_setup": _make_handler(android_setup, target_device=False),
+    "android_clipboard_read": _make_handler(android_clipboard_read, pass_args=False),
+    "android_clipboard_write": _make_handler(android_clipboard_write),
+    "android_notifications": _make_handler(android_notifications),
+    "android_long_press": _make_handler(android_long_press),
+    "android_drag": _make_handler(android_drag),
+    "android_describe_node": _make_handler(android_describe_node),
+    "android_screen_hash": _make_handler(android_screen_hash, pass_args=False),
+    "android_macro": _make_handler(android_macro),
+    "android_location": _make_handler(android_location, pass_args=False),
+    "android_send_sms": _make_handler(android_send_sms),
+    "android_call": _make_handler(android_call),
+    "android_speak": _make_handler(android_speak),
+    "android_speak_stop": _make_handler(android_speak_stop, pass_args=False),
+    "android_events": _make_handler(android_events),
+    "android_event_stream": _make_handler(android_event_stream),
+    "android_screen_record": _make_handler(android_screen_record),
+    "android_read_widgets": _make_handler(android_read_widgets, pass_args=False),
+    "android_find_nodes": _make_handler(android_find_nodes),
+    "android_diff_screen": _make_handler(android_diff_screen),
+    "android_pinch": _make_handler(android_pinch),
+    "android_media": _make_handler(android_media),
+    "android_search_contacts": _make_handler(android_search_contacts),
+    "android_send_intent": _make_handler(android_send_intent),
+    "android_broadcast": _make_handler(android_broadcast),
 }

--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -12,9 +12,10 @@ via ctx.register_tool().
 import json
 import os
 import time
+import contextvars
 import requests
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 # ── Config ────────────────────────────────────────────────────────────────────
 #
@@ -34,6 +35,15 @@ def _bridge_url() -> str:
 
 def _bridge_token() -> Optional[str]:
     return os.getenv("ANDROID_BRIDGE_TOKEN")
+
+
+_CURRENT_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "android_device", default=None
+)
+
+
+def _selected_device(device: Optional[str] = None) -> Optional[str]:
+    return device or _CURRENT_DEVICE.get() or os.getenv("ANDROID_DEFAULT_DEVICE")
 
 
 def _relay_port() -> int:
@@ -82,9 +92,17 @@ def _extract_response(r: requests.Response) -> dict:
     return body
 
 
-def _post(path: str, payload: dict) -> dict:
+def _with_device(path: str, device: Optional[str] = None) -> str:
+    selected = _selected_device(device)
+    if not selected or path.startswith("/devices"):
+        return path
+    separator = "&" if "?" in path else "?"
+    return f"{path}{separator}{urlencode({'device': selected})}"
+
+
+def _post(path: str, payload: dict, device: Optional[str] = None) -> dict:
     r = requests.post(
-        f"{_bridge_url()}{path}",
+        f"{_bridge_url()}{_with_device(path, device)}",
         json=payload,
         headers=_auth_headers(),
         timeout=_timeout(),
@@ -92,9 +110,11 @@ def _post(path: str, payload: dict) -> dict:
     return _extract_response(r)
 
 
-def _get(path: str) -> dict:
+def _get(path: str, device: Optional[str] = None) -> dict:
     r = requests.get(
-        f"{_bridge_url()}{path}", headers=_auth_headers(), timeout=_timeout()
+        f"{_bridge_url()}{_with_device(path, device)}",
+        headers=_auth_headers(),
+        timeout=_timeout(),
     )
     return _extract_response(r)
 
@@ -108,6 +128,15 @@ def android_ping() -> str:
         return json.dumps({"status": "ok", "bridge": data})
     except Exception as e:
         return json.dumps({"status": "error", "message": str(e)})
+
+
+def android_devices() -> str:
+    """List configured Android devices and whether each one is connected."""
+    try:
+        data = _get("/devices")
+        return json.dumps(data)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
 
 
 def android_read_screen(include_bounds: bool = False) -> str:
@@ -739,6 +768,12 @@ def android_setup(pairing_code: str) -> str:
     try:
         port = _relay_port()
         public_ip = _get_public_ip()
+        pairing_codes = [
+            code.strip().upper()
+            for code in pairing_code.replace(";", ",").split(",")
+            if code.strip()
+        ]
+        bridge_token = pairing_codes[0] if pairing_codes else pairing_code
 
         # Save config to ~/.hermes/.env
         relay_url = f"http://localhost:{port}"
@@ -746,7 +781,8 @@ def android_setup(pairing_code: str) -> str:
             from hermes_cli.config import save_env_value
 
             save_env_value("ANDROID_BRIDGE_URL", relay_url)
-            save_env_value("ANDROID_BRIDGE_TOKEN", pairing_code)
+            save_env_value("ANDROID_BRIDGE_TOKEN", bridge_token)
+            save_env_value("ANDROID_BRIDGE_TOKENS", ",".join(pairing_codes))
             save_env_value("ANDROID_RELAY_PORT", str(port))
         except ImportError:
             from pathlib import Path
@@ -754,12 +790,14 @@ def android_setup(pairing_code: str) -> str:
             env_path = Path.home() / ".hermes" / ".env"
             env_path.parent.mkdir(parents=True, exist_ok=True)
             _update_env_file(env_path, "ANDROID_BRIDGE_URL", relay_url)
-            _update_env_file(env_path, "ANDROID_BRIDGE_TOKEN", pairing_code)
+            _update_env_file(env_path, "ANDROID_BRIDGE_TOKEN", bridge_token)
+            _update_env_file(env_path, "ANDROID_BRIDGE_TOKENS", ",".join(pairing_codes))
             _update_env_file(env_path, "ANDROID_RELAY_PORT", str(port))
 
         # Update current process env
         os.environ["ANDROID_BRIDGE_URL"] = relay_url
-        os.environ["ANDROID_BRIDGE_TOKEN"] = pairing_code
+        os.environ["ANDROID_BRIDGE_TOKEN"] = bridge_token
+        os.environ["ANDROID_BRIDGE_TOKENS"] = ",".join(pairing_codes)
 
         # Start the relay server
         try:
@@ -833,6 +871,11 @@ _SCHEMAS = {
     "android_ping": {
         "name": "android_ping",
         "description": "Check if the Android bridge is reachable. Call this first before any other android_ tools.",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_devices": {
+        "name": "android_devices",
+        "description": "List configured Android devices and whether each device is connected. Use this before targeting a specific device.",
         "parameters": {"type": "object", "properties": {}, "required": []},
     },
     "android_read_screen": {
@@ -1403,45 +1446,67 @@ _SCHEMAS = {
     },
 }
 
+_DEVICE_PARAMETER = {
+    "type": "string",
+    "description": "Optional Android device alias or pairing token to target when multiple devices are connected.",
+}
+
+for _tool_name, _schema in _SCHEMAS.items():
+    if _tool_name in {"android_setup", "android_devices"}:
+        continue
+    _schema["parameters"].setdefault("properties", {})["device"] = _DEVICE_PARAMETER
+
+
 # ── Tool handlers map ──────────────────────────────────────────────────────────
 
+
+def _with_target_device(args: dict, handler):
+    call_args = dict(args or {})
+    device = call_args.pop("device", None)
+    token = _CURRENT_DEVICE.set(device)
+    try:
+        return handler(call_args)
+    finally:
+        _CURRENT_DEVICE.reset(token)
+
 _HANDLERS = {
-    "android_ping": lambda args, **kw: android_ping(),
-    "android_read_screen": lambda args, **kw: android_read_screen(**args),
-    "android_tap": lambda args, **kw: android_tap(**args),
-    "android_tap_text": lambda args, **kw: android_tap_text(**args),
-    "android_type": lambda args, **kw: android_type(**args),
-    "android_swipe": lambda args, **kw: android_swipe(**args),
-    "android_open_app": lambda args, **kw: android_open_app(**args),
-    "android_press_key": lambda args, **kw: android_press_key(**args),
-    "android_screenshot": lambda args, **kw: android_screenshot(),
-    "android_scroll": lambda args, **kw: android_scroll(**args),
-    "android_wait": lambda args, **kw: android_wait(**args),
-    "android_get_apps": lambda args, **kw: android_get_apps(),
-    "android_current_app": lambda args, **kw: android_current_app(),
+    "android_ping": lambda args, **kw: _with_target_device(args, lambda _args: android_ping()),
+    "android_devices": lambda args, **kw: android_devices(),
+    "android_read_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_read_screen(**call_args)),
+    "android_tap": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap(**call_args)),
+    "android_tap_text": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap_text(**call_args)),
+    "android_type": lambda args, **kw: _with_target_device(args, lambda call_args: android_type(**call_args)),
+    "android_swipe": lambda args, **kw: _with_target_device(args, lambda call_args: android_swipe(**call_args)),
+    "android_open_app": lambda args, **kw: _with_target_device(args, lambda call_args: android_open_app(**call_args)),
+    "android_press_key": lambda args, **kw: _with_target_device(args, lambda call_args: android_press_key(**call_args)),
+    "android_screenshot": lambda args, **kw: _with_target_device(args, lambda _args: android_screenshot()),
+    "android_scroll": lambda args, **kw: _with_target_device(args, lambda call_args: android_scroll(**call_args)),
+    "android_wait": lambda args, **kw: _with_target_device(args, lambda call_args: android_wait(**call_args)),
+    "android_get_apps": lambda args, **kw: _with_target_device(args, lambda _args: android_get_apps()),
+    "android_current_app": lambda args, **kw: _with_target_device(args, lambda _args: android_current_app()),
     "android_setup": lambda args, **kw: android_setup(**args),
-    "android_clipboard_read": lambda args, **kw: android_clipboard_read(),
-    "android_clipboard_write": lambda args, **kw: android_clipboard_write(**args),
-    "android_notifications": lambda args, **kw: android_notifications(**args),
-    "android_long_press": lambda args, **kw: android_long_press(**args),
-    "android_drag": lambda args, **kw: android_drag(**args),
-    "android_describe_node": lambda args, **kw: android_describe_node(**args),
-    "android_screen_hash": lambda args, **kw: android_screen_hash(),
-    "android_macro": lambda args, **kw: android_macro(**args),
-    "android_location": lambda args, **kw: android_location(),
-    "android_send_sms": lambda args, **kw: android_send_sms(**args),
-    "android_call": lambda args, **kw: android_call(**args),
-    "android_speak": lambda args, **kw: android_speak(**args),
-    "android_speak_stop": lambda args, **kw: android_speak_stop(),
-    "android_events": lambda args, **kw: android_events(**args),
-    "android_event_stream": lambda args, **kw: android_event_stream(**args),
-    "android_screen_record": lambda args, **kw: android_screen_record(**args),
-    "android_read_widgets": lambda args, **kw: android_read_widgets(),
-    "android_find_nodes": lambda args, **kw: android_find_nodes(**args),
-    "android_diff_screen": lambda args, **kw: android_diff_screen(**args),
-    "android_pinch": lambda args, **kw: android_pinch(**args),
-    "android_media": lambda args, **kw: android_media(**args),
-    "android_search_contacts": lambda args, **kw: android_search_contacts(**args),
-    "android_send_intent": lambda args, **kw: android_send_intent(**args),
-    "android_broadcast": lambda args, **kw: android_broadcast(**args),
+    "android_clipboard_read": lambda args, **kw: _with_target_device(args, lambda _args: android_clipboard_read()),
+    "android_clipboard_write": lambda args, **kw: _with_target_device(args, lambda call_args: android_clipboard_write(**call_args)),
+    "android_notifications": lambda args, **kw: _with_target_device(args, lambda call_args: android_notifications(**call_args)),
+    "android_long_press": lambda args, **kw: _with_target_device(args, lambda call_args: android_long_press(**call_args)),
+    "android_drag": lambda args, **kw: _with_target_device(args, lambda call_args: android_drag(**call_args)),
+    "android_describe_node": lambda args, **kw: _with_target_device(args, lambda call_args: android_describe_node(**call_args)),
+    "android_screen_hash": lambda args, **kw: _with_target_device(args, lambda _args: android_screen_hash()),
+    "android_macro": lambda args, **kw: _with_target_device(args, lambda call_args: android_macro(**call_args)),
+    "android_location": lambda args, **kw: _with_target_device(args, lambda _args: android_location()),
+    "android_send_sms": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_sms(**call_args)),
+    "android_call": lambda args, **kw: _with_target_device(args, lambda call_args: android_call(**call_args)),
+    "android_speak": lambda args, **kw: _with_target_device(args, lambda call_args: android_speak(**call_args)),
+    "android_speak_stop": lambda args, **kw: _with_target_device(args, lambda _args: android_speak_stop()),
+    "android_events": lambda args, **kw: _with_target_device(args, lambda call_args: android_events(**call_args)),
+    "android_event_stream": lambda args, **kw: _with_target_device(args, lambda call_args: android_event_stream(**call_args)),
+    "android_screen_record": lambda args, **kw: _with_target_device(args, lambda call_args: android_screen_record(**call_args)),
+    "android_read_widgets": lambda args, **kw: _with_target_device(args, lambda _args: android_read_widgets()),
+    "android_find_nodes": lambda args, **kw: _with_target_device(args, lambda call_args: android_find_nodes(**call_args)),
+    "android_diff_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_diff_screen(**call_args)),
+    "android_pinch": lambda args, **kw: _with_target_device(args, lambda call_args: android_pinch(**call_args)),
+    "android_media": lambda args, **kw: _with_target_device(args, lambda call_args: android_media(**call_args)),
+    "android_search_contacts": lambda args, **kw: _with_target_device(args, lambda call_args: android_search_contacts(**call_args)),
+    "android_send_intent": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_intent(**call_args)),
+    "android_broadcast": lambda args, **kw: _with_target_device(args, lambda call_args: android_broadcast(**call_args)),
 }

--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -40,10 +40,16 @@ def _bridge_token() -> Optional[str]:
 _CURRENT_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "android_device", default=None
 )
+_ACTIVE_DEVICE: Optional[str] = None
 
 
 def _selected_device(device: Optional[str] = None) -> Optional[str]:
-    return device or _CURRENT_DEVICE.get() or os.getenv("ANDROID_DEFAULT_DEVICE")
+    return (
+        device
+        or _CURRENT_DEVICE.get()
+        or _ACTIVE_DEVICE
+        or os.getenv("ANDROID_DEFAULT_DEVICE")
+    )
 
 
 def _relay_port() -> int:
@@ -134,7 +140,67 @@ def android_devices() -> str:
     """List configured Android devices and whether each one is connected."""
     try:
         data = _get("/devices")
+        data["active_device"] = _selected_device()
+        data["usage"] = (
+            "Use android_select_device(device) before a multi-step task, or pass "
+            "device to individual android_* calls. Call android_read_screen after "
+            "selecting a device before tapping."
+        )
         return json.dumps(data)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_select_device(device: str) -> str:
+    """
+    Select the Android device that subsequent android_* tool calls should target.
+    Use a device alias from android_devices(), such as 'old' or 'lrw2u7'.
+    """
+    global _ACTIVE_DEVICE
+    try:
+        requested = str(device).strip()
+        if not requested:
+            return json.dumps({"error": "device is required"})
+
+        data = _get("/devices")
+        devices = data.get("devices", [])
+        connected = []
+        for item in devices:
+            aliases = [item.get("device"), *item.get("aliases", [])]
+            aliases = [str(alias) for alias in aliases if alias]
+            if item.get("connected"):
+                connected.append(item.get("device"))
+            if requested.lower() in {alias.lower() for alias in aliases}:
+                if not item.get("connected"):
+                    return json.dumps(
+                        {
+                            "error": f"Android device '{requested}' is configured but not connected.",
+                            "devices": devices,
+                        }
+                    )
+                _ACTIVE_DEVICE = item.get("device") or requested
+                return json.dumps(
+                    {
+                        "status": "ok",
+                        "active_device": _ACTIVE_DEVICE,
+                        "message": (
+                            f"Selected Android device '{_ACTIVE_DEVICE}'. "
+                            "Subsequent android_* calls will target it unless a device argument is provided."
+                        ),
+                        "devices": devices,
+                    }
+                )
+
+        return json.dumps(
+            {
+                "error": (
+                    f"Unknown Android device '{requested}'. Call android_devices and choose "
+                    "one of the listed device names or aliases."
+                ),
+                "connected_devices": connected,
+                "devices": devices,
+            }
+        )
     except Exception as e:
         return json.dumps({"error": str(e)})
 
@@ -875,8 +941,22 @@ _SCHEMAS = {
     },
     "android_devices": {
         "name": "android_devices",
-        "description": "List configured Android devices and whether each device is connected. Use this before targeting a specific device.",
+        "description": "List configured Android devices, aliases, connection state, and the currently selected target device. Use this before choosing a device.",
         "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_select_device": {
+        "name": "android_select_device",
+        "description": "Select which Android device subsequent android_* calls should target. Call android_devices first when the user refers to a phone ambiguously. After selecting, call android_read_screen before tapping.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "device": {
+                    "type": "string",
+                    "description": "Device alias from android_devices, such as old, new, lrw2u7, or emdmfu.",
+                }
+            },
+            "required": ["device"],
+        },
     },
     "android_read_screen": {
         "name": "android_read_screen",
@@ -1452,7 +1532,7 @@ _DEVICE_PARAMETER = {
 }
 
 for _tool_name, _schema in _SCHEMAS.items():
-    if _tool_name in {"android_setup", "android_devices"}:
+    if _tool_name in {"android_setup", "android_devices", "android_select_device"}:
         continue
     _schema["parameters"].setdefault("properties", {})["device"] = _DEVICE_PARAMETER
 
@@ -1472,6 +1552,7 @@ def _with_target_device(args: dict, handler):
 _HANDLERS = {
     "android_ping": lambda args, **kw: _with_target_device(args, lambda _args: android_ping()),
     "android_devices": lambda args, **kw: android_devices(),
+    "android_select_device": lambda args, **kw: android_select_device(**args),
     "android_read_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_read_screen(**call_args)),
     "android_tap": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap(**call_args)),
     "android_tap_text": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap_text(**call_args)),

--- a/hermes-android-plugin/skill.md
+++ b/hermes-android-plugin/skill.md
@@ -48,11 +48,20 @@ After the user taps Connect on their phone, the phone connects to this server vi
 
 ## Available Tools
 
-You have these 38 tools. Use them by name — they are function calls.
+You have these 40 tools. Use them by name — they are function calls.
 
 ### Connectivity
 - `android_ping()` — check if phone is connected and responding
 - `android_setup(pairing_code)` — start relay and configure connection
+- `android_devices()` — list connected/configured devices, aliases, and current selected target
+- `android_select_device(device)` — select the target device for subsequent android_* calls
+
+### Multiple Devices
+- If more than one device is connected and the user's target is not explicit, call `android_devices()` first.
+- Use `android_select_device(device)` before a multi-step task so every following read/tap/type command goes to the same phone.
+- If the user explicitly names a device alias or token, pass `device="<alias>"` to the tool call or select it first.
+- After selecting a device, always call `android_read_screen()` before tapping or typing.
+- When reporting actions, include the selected device alias so the user can verify the target.
 
 ### Reading the Screen
 - `android_read_screen(include_bounds=False)` — get the full accessibility tree as JSON. Returns every visible UI element with text, className, nodeId, clickable, etc. **Always call this before interacting.**

--- a/tests/test_android_relay.py
+++ b/tests/test_android_relay.py
@@ -85,6 +85,20 @@ class TestRelayLifecycle:
         assert state.device_aliases == {"old": "LRW2U7", "new": "EMDMFU"}
         assert _device_aliases(state, "LRW2U7") == ["old", "LRW2U7"]
 
+    def test_device_name_prefers_token_alias_over_first_alias(self, monkeypatch):
+        from tools.android_relay import _device_name
+
+        monkeypatch.setenv("ANDROID_BRIDGE_DEVICES", "work=LRW2U7,lrw2u7=LRW2U7")
+        state = _RelayState("LRW2U7", 19882)
+        assert _device_name(state, "LRW2U7") == "lrw2u7"
+
+    def test_device_name_falls_back_to_token_when_aliases_are_labels(self, monkeypatch):
+        from tools.android_relay import _device_name
+
+        monkeypatch.setenv("ANDROID_BRIDGE_DEVICES", "work=LRW2U7,primary=LRW2U7")
+        state = _RelayState("LRW2U7", 19883)
+        assert _device_name(state, "LRW2U7") == "LRW2U7"
+
 
 class TestRateLimiting:
     def test_not_blocked_initially(self):

--- a/tests/test_android_relay.py
+++ b/tests/test_android_relay.py
@@ -7,6 +7,7 @@ from tools.android_relay import (
     is_phone_connected,
     get_relay_url,
     set_pairing_code,
+    _RelayState,
     _auth_is_blocked,
     _auth_record_failure,
     _auth_lock,
@@ -67,6 +68,20 @@ class TestRelayLifecycle:
         start_relay(pairing_code="NEPCODE", port=19878)
         assert is_relay_running()
         stop_relay()
+
+    def test_state_accepts_multiple_pairing_codes(self):
+        state = _RelayState("FIRST1,SECOND2", 19879)
+        assert state.pairing_codes == {"FIRST1", "SECOND2"}
+
+    def test_state_accepts_tokens_from_env(self, monkeypatch):
+        monkeypatch.setenv("ANDROID_BRIDGE_TOKENS", "THIRD3,FOURTH4")
+        state = _RelayState("FIRST1", 19880)
+        assert state.pairing_codes == {"FIRST1", "THIRD3", "FOURTH4"}
+
+    def test_device_aliases_from_env(self, monkeypatch):
+        monkeypatch.setenv("ANDROID_BRIDGE_DEVICES", "old=LRW2U7,new=EMDMFU")
+        state = _RelayState("LRW2U7,EMDMFU", 19881)
+        assert state.device_aliases == {"old": "LRW2U7", "new": "EMDMFU"}
 
 
 class TestRateLimiting:

--- a/tests/test_android_relay.py
+++ b/tests/test_android_relay.py
@@ -15,6 +15,7 @@ from tools.android_relay import (
     _auth_failures,
     _AUTH_MAX_ATTEMPTS,
     _mask_token,
+    _device_aliases,
 )
 
 
@@ -82,6 +83,7 @@ class TestRelayLifecycle:
         monkeypatch.setenv("ANDROID_BRIDGE_DEVICES", "old=LRW2U7,new=EMDMFU")
         state = _RelayState("LRW2U7,EMDMFU", 19881)
         assert state.device_aliases == {"old": "LRW2U7", "new": "EMDMFU"}
+        assert _device_aliases(state, "LRW2U7") == ["old", "LRW2U7"]
 
 
 class TestRateLimiting:

--- a/tests/test_android_tool.py
+++ b/tests/test_android_tool.py
@@ -7,6 +7,7 @@ import pytest
 from tools.android_tool import (
     android_ping,
     android_devices,
+    android_select_device,
     android_read_screen,
     android_tap,
     android_tap_text,
@@ -49,12 +50,21 @@ from tools.android_tool import (
 )
 
 
-class TestSchemas:
-    def test_all_39_tools_have_schemas(self):
-        assert len(_SCHEMAS) == 39
+@pytest.fixture(autouse=True)
+def reset_active_device():
+    import tools.android_tool as mod
 
-    def test_all_39_tools_have_handlers(self):
-        assert len(_HANDLERS) == 39
+    mod._ACTIVE_DEVICE = None
+    yield
+    mod._ACTIVE_DEVICE = None
+
+
+class TestSchemas:
+    def test_all_40_tools_have_schemas(self):
+        assert len(_SCHEMAS) == 40
+
+    def test_all_40_tools_have_handlers(self):
+        assert len(_HANDLERS) == 40
 
     def test_schema_names_match_handler_names(self):
         assert set(_SCHEMAS.keys()) == set(_HANDLERS.keys())
@@ -70,6 +80,10 @@ class TestSchemas:
             properties = schema["parameters"].get("properties", {})
             if name in {"android_setup", "android_devices"}:
                 assert "device" not in properties
+            elif name == "android_select_device":
+                assert properties["device"]["description"].startswith(
+                    "Device alias from android_devices"
+                )
             else:
                 assert "device" in properties
 
@@ -123,6 +137,74 @@ class TestDevices:
         )
         result = json.loads(android_devices())
         assert result["devices"][0]["device"] == "phone-a"
+        assert result["active_device"] is None
+        assert "android_select_device" in result["usage"]
+
+    @responses.activate
+    def test_select_device_sets_active_target(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/devices",
+            json={
+                "devices": [
+                    {
+                        "device": "phone-a",
+                        "aliases": ["old", "LRW2U7"],
+                        "connected": True,
+                    }
+                ]
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/ping?device=phone-a",
+            json={"status": "ok", "accessibilityService": True},
+        )
+
+        selected = json.loads(android_select_device("old"))
+        assert selected["status"] == "ok"
+        assert selected["active_device"] == "phone-a"
+
+        result = json.loads(android_ping())
+        assert result["status"] == "ok"
+
+    @responses.activate
+    def test_select_device_rejects_disconnected_device(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/devices",
+            json={
+                "devices": [
+                    {
+                        "device": "phone-a",
+                        "aliases": ["old", "LRW2U7"],
+                        "connected": False,
+                    }
+                ]
+            },
+        )
+        result = json.loads(android_select_device("old"))
+        assert "error" in result
+        assert "not connected" in result["error"]
+
+    @responses.activate
+    def test_select_device_rejects_unknown_device(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/devices",
+            json={
+                "devices": [
+                    {
+                        "device": "phone-a",
+                        "aliases": ["old", "LRW2U7"],
+                        "connected": True,
+                    }
+                ]
+            },
+        )
+        result = json.loads(android_select_device("missing"))
+        assert "error" in result
+        assert "Unknown Android device" in result["error"]
 
     @responses.activate
     def test_handler_targets_device(self, bridge_url):
@@ -132,6 +214,33 @@ class TestDevices:
             json={"status": "ok", "accessibilityService": True},
         )
         result = json.loads(_HANDLERS["android_ping"]({"device": "phone-a"}))
+        assert result["status"] == "ok"
+
+    @responses.activate
+    def test_handler_device_overrides_active_target(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/devices",
+            json={
+                "devices": [
+                    {
+                        "device": "phone-a",
+                        "aliases": ["old"],
+                        "connected": True,
+                    }
+                ]
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/ping?device=phone-b",
+            json={"status": "ok", "accessibilityService": True},
+        )
+
+        selected = json.loads(android_select_device("old"))
+        assert selected["active_device"] == "phone-a"
+
+        result = json.loads(_HANDLERS["android_ping"]({"device": "phone-b"}))
         assert result["status"] == "ok"
 
 

--- a/tests/test_android_tool.py
+++ b/tests/test_android_tool.py
@@ -54,9 +54,9 @@ from tools.android_tool import (
 def reset_active_device():
     import tools.android_tool as mod
 
-    mod._ACTIVE_DEVICE = None
+    token = mod._ACTIVE_DEVICE.set(None)
     yield
-    mod._ACTIVE_DEVICE = None
+    mod._ACTIVE_DEVICE.reset(token)
 
 
 class TestSchemas:
@@ -157,13 +157,14 @@ class TestDevices:
         )
         responses.add(
             responses.GET,
-            f"{bridge_url}/ping?device=phone-a",
+            f"{bridge_url}/ping?device=old",
             json={"status": "ok", "accessibilityService": True},
         )
 
         selected = json.loads(android_select_device("old"))
         assert selected["status"] == "ok"
-        assert selected["active_device"] == "phone-a"
+        assert selected["active_device"] == "old"
+        assert selected["matched_device"] == "phone-a"
 
         result = json.loads(android_ping())
         assert result["status"] == "ok"
@@ -238,10 +239,20 @@ class TestDevices:
         )
 
         selected = json.loads(android_select_device("old"))
-        assert selected["active_device"] == "phone-a"
+        assert selected["active_device"] == "old"
 
         result = json.loads(_HANDLERS["android_ping"]({"device": "phone-b"}))
         assert result["status"] == "ok"
+
+    def test_active_device_is_context_local(self):
+        import contextvars
+        import tools.android_tool as mod
+
+        ctx = contextvars.copy_context()
+        ctx.run(mod._ACTIVE_DEVICE.set, "phone-a")
+
+        assert ctx.run(mod._selected_device) == "phone-a"
+        assert mod._selected_device() is None
 
 
 class TestReadScreen:

--- a/tests/test_android_tool.py
+++ b/tests/test_android_tool.py
@@ -6,6 +6,7 @@ import pytest
 # Import tool functions directly (not via registry)
 from tools.android_tool import (
     android_ping,
+    android_devices,
     android_read_screen,
     android_tap,
     android_tap_text,
@@ -49,11 +50,11 @@ from tools.android_tool import (
 
 
 class TestSchemas:
-    def test_all_38_tools_have_schemas(self):
-        assert len(_SCHEMAS) == 38
+    def test_all_39_tools_have_schemas(self):
+        assert len(_SCHEMAS) == 39
 
-    def test_all_38_tools_have_handlers(self):
-        assert len(_HANDLERS) == 38
+    def test_all_39_tools_have_handlers(self):
+        assert len(_HANDLERS) == 39
 
     def test_schema_names_match_handler_names(self):
         assert set(_SCHEMAS.keys()) == set(_HANDLERS.keys())
@@ -63,6 +64,14 @@ class TestSchemas:
             assert "name" in schema, f"{name} missing 'name'"
             assert "description" in schema, f"{name} missing 'description'"
             assert "parameters" in schema, f"{name} missing 'parameters'"
+
+    def test_device_parameter_added_to_targetable_tools(self):
+        for name, schema in _SCHEMAS.items():
+            properties = schema["parameters"].get("properties", {})
+            if name in {"android_setup", "android_devices"}:
+                assert "device" not in properties
+            else:
+                assert "device" in properties
 
 
 class TestCodeQuality:
@@ -102,6 +111,28 @@ class TestPing:
         )
         result = json.loads(android_ping())
         assert result["status"] == "error"
+
+
+class TestDevices:
+    @responses.activate
+    def test_devices(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/devices",
+            json={"devices": [{"device": "phone-a", "connected": True}]},
+        )
+        result = json.loads(android_devices())
+        assert result["devices"][0]["device"] == "phone-a"
+
+    @responses.activate
+    def test_handler_targets_device(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/ping?device=phone-a",
+            json={"status": "ok", "accessibilityService": True},
+        )
+        result = json.loads(_HANDLERS["android_ping"]({"device": "phone-a"}))
+        assert result["status"] == "ok"
 
 
 class TestReadScreen:

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -48,7 +48,11 @@ class _RelayState:
     """Holds all mutable state for one running relay instance."""
 
     def __init__(self, pairing_code: str, port: int):
-        self.pairing_code: str = pairing_code
+        self.pairing_codes: set[str] = _parse_pairing_codes(pairing_code)
+        self.device_aliases: dict[str, str] = _parse_device_aliases()
+        self.default_device: Optional[str] = _normalize_token(
+            os.getenv("ANDROID_DEFAULT_DEVICE", "")
+        )
         self.port: int = port
 
         # asyncio loop running in the background thread
@@ -60,12 +64,12 @@ class _RelayState:
         self.runner: Optional[web.AppRunner] = None
         self.site: Optional[web.TCPSite] = None
 
-        # The single connected phone WebSocket (or None)
-        self.phone_ws: Optional[web.WebSocketResponse] = None
+        # Connected phone WebSockets keyed by pairing token.
+        self.phone_ws: dict[str, web.WebSocketResponse] = {}
         self.phone_ws_lock = asyncio.Lock()  # created lazily in the event loop
 
-        # Pending requests: request_id -> asyncio.Future
-        self.pending: dict[str, asyncio.Future] = {}
+        # Pending requests: request_id -> (asyncio.Future, token)
+        self.pending: dict[str, tuple[asyncio.Future, str]] = {}
         self.pending_lock: Optional[asyncio.Lock] = None  # created lazily
 
         # Shutdown event
@@ -73,6 +77,41 @@ class _RelayState:
 
 
 # ── Public API (called from sync code) ────────────────────────────────────────
+
+
+def _normalize_token(token: str) -> str:
+    return token.strip().upper()
+
+
+def _parse_pairing_codes(pairing_code: str) -> set[str]:
+    raw_codes = [pairing_code, os.getenv("ANDROID_BRIDGE_TOKENS", "")]
+    codes: set[str] = set()
+    for raw in raw_codes:
+        for code in raw.replace(";", ",").split(","):
+            normalized = _normalize_token(code)
+            if normalized:
+                codes.add(normalized)
+    if not codes:
+        raise ValueError("At least one pairing code is required")
+    return codes
+
+
+def _parse_device_aliases() -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    raw = os.getenv("ANDROID_BRIDGE_DEVICES", "")
+    for entry in raw.replace(";", ",").split(","):
+        if "=" not in entry:
+            continue
+        alias, token = entry.split("=", 1)
+        normalized_alias = alias.strip()
+        normalized_token = _normalize_token(token)
+        if normalized_alias and normalized_token:
+            aliases[normalized_alias] = normalized_token
+    return aliases
+
+
+def _mask_token(token: str) -> str:
+    return (token[:2] + "****") if len(token) >= 2 else "****"
 
 
 def start_relay(pairing_code: str, port: int = 0) -> None:
@@ -134,8 +173,7 @@ def is_phone_connected() -> bool:
         s = _relay_instance
         if s is None:
             return False
-        ws = s.phone_ws
-        return ws is not None and not ws.closed
+        return any(not ws.closed for ws in s.phone_ws.values())
 
 
 def get_relay_url() -> str:
@@ -150,7 +188,7 @@ def set_pairing_code(code: str) -> None:
     with _relay_lock:
         s = _relay_instance
         if s is not None:
-            s.pairing_code = code
+            s.pairing_codes = _parse_pairing_codes(code)
             logger.info("Pairing code updated")
 
 
@@ -197,6 +235,7 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
 
     # WebSocket endpoint
     app.router.add_get("/ws", lambda req: _handle_ws(req, state))
+    app.router.add_get("/devices", lambda req: _handle_devices(req, state))
 
     # HTTP bridge endpoints — method per path
     ROUTES = {
@@ -264,7 +303,7 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
     await state.shutdown_event.wait()
 
     # Cleanup
-    await _cleanup_phone(state, reason="relay shutdown")
+    await _cleanup_all_phones(state, reason="relay shutdown")
     await runner.cleanup()
     logger.info("Relay server cleaned up")
 
@@ -359,29 +398,32 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
             text="Too many failed authentication attempts. Try again later."
         )
 
-    token = request.query.get("token", "")
+    token = _normalize_token(request.query.get("token", ""))
     # Constant-time comparison to mitigate timing side-channel attacks that
     # could otherwise leak the pairing code byte-by-byte.
-    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
+    if not any(hmac.compare_digest(token, code) for code in state.pairing_codes):
         _auth_record_failure(remote_ip)
         logger.warning(
-            "Phone WS rejected — bad token (got %s) from %s", _mask_token(token), remote_ip
+            "Phone WS rejected — bad token (got %s) from %s",
+            _mask_token(token),
+            remote_ip,
         )
         raise web.HTTPForbidden(text="Invalid pairing code")
 
     ws = web.WebSocketResponse(heartbeat=15.0)
     await ws.prepare(request)
 
-    # Only one phone at a time — kick previous if any
+    # Keep one connection per token. A reconnect replaces only that device.
     async with state.phone_ws_lock:
-        if state.phone_ws is not None and not state.phone_ws.closed:
-            logger.info("Replacing previous phone connection")
-            await state.phone_ws.close(
+        existing = state.phone_ws.get(token)
+        if existing is not None and not existing.closed:
+            logger.info("Replacing previous phone connection for token=%s", _mask_token(token))
+            await existing.close(
                 code=aiohttp.WSCloseCode.GOING_AWAY, message=b"replaced"
             )
-        state.phone_ws = ws
+        state.phone_ws[token] = ws
 
-    logger.info("Phone connected from %s", request.remote)
+    logger.info("Phone connected from %s token=%s", request.remote, _mask_token(token))
 
     try:
         async for msg in ws:
@@ -391,7 +433,7 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
                 logger.error("Phone WS error: %s", ws.exception())
                 break
     finally:
-        await _cleanup_phone(state, reason="phone disconnected")
+        await _cleanup_phone(state, token, ws, reason="phone disconnected")
 
     return ws
 
@@ -410,31 +452,45 @@ async def _on_phone_message(state: _RelayState, raw: str) -> None:
         return
 
     async with state.pending_lock:
-        future = state.pending.pop(request_id, None)
+        pending = state.pending.pop(request_id, None)
 
-    if future is None:
+    if pending is None:
         logger.debug(
             "No pending future for request_id=%s (possibly timed out)", request_id
         )
         return
 
+    future, _token = pending
     if not future.done():
         future.set_result(data)
 
 
-async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
-    """Clean up phone connection and cancel all pending requests."""
+async def _cleanup_phone(
+    state: _RelayState,
+    token: str,
+    ws: Optional[web.WebSocketResponse] = None,
+    reason: str = "",
+) -> None:
+    """Clean up one phone connection and cancel pending requests for that token."""
     async with state.phone_ws_lock:
-        ws = state.phone_ws
-        state.phone_ws = None
+        current = state.phone_ws.get(token)
+        if ws is None:
+            ws = current
+        if current is ws:
+            state.phone_ws.pop(token, None)
 
     if ws is not None and not ws.closed:
         await ws.close()
 
-    # Fail all pending futures
+    # Fail pending futures for this device only.
     async with state.pending_lock:
-        pending = dict(state.pending)
-        state.pending.clear()
+        pending = {
+            rid: fut
+            for rid, (fut, pending_token) in state.pending.items()
+            if pending_token == token
+        }
+        for rid in pending:
+            state.pending.pop(rid, None)
 
     for rid, fut in pending.items():
         if not fut.done():
@@ -444,21 +500,114 @@ async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
         logger.info("Cancelled %d pending requests (%s)", len(pending), reason)
 
 
+async def _cleanup_all_phones(state: _RelayState, reason: str = "") -> None:
+    async with state.phone_ws_lock:
+        phones = list(state.phone_ws.items())
+    for token, ws in phones:
+        await _cleanup_phone(state, token, ws, reason=reason)
+
+
 # ── HTTP handler (tool side) ─────────────────────────────────────────────────
 
 _RESPONSE_TIMEOUT = 30  # seconds
+
+
+def _device_name(state: _RelayState, token: str) -> str:
+    for alias, alias_token in state.device_aliases.items():
+        if alias_token == token:
+            return alias
+    return token
+
+
+def _resolve_requested_token(
+    state: _RelayState,
+    request: web.Request,
+    body: Optional[dict] = None,
+) -> tuple[Optional[str], Optional[web.Response]]:
+    requested = (
+        request.query.get("device")
+        or request.query.get("token")
+        or request.query.get("target_device")
+        or request.headers.get("X-Android-Device")
+    )
+    if body:
+        requested = requested or body.pop("device", None) or body.pop("target_device", None)
+
+    if requested:
+        requested_text = str(requested).strip()
+        token = state.device_aliases.get(requested_text, _normalize_token(requested_text))
+        if token not in state.pairing_codes:
+            return None, web.json_response(
+                {"error": f"Unknown Android device '{requested_text}'"},
+                status=404,
+            )
+        return token, None
+
+    if state.default_device:
+        token = state.device_aliases.get(state.default_device, state.default_device)
+        if token in state.pairing_codes:
+            return token, None
+
+    connected = [token for token, ws in state.phone_ws.items() if not ws.closed]
+    if len(connected) == 1:
+        return connected[0], None
+
+    if not connected:
+        return None, web.json_response(
+            {
+                "error": "No phone connected. Open the Hermes app on your phone and connect."
+            },
+            status=503,
+        )
+
+    return None, web.json_response(
+        {
+            "error": "Multiple phones are connected. Specify device.",
+            "devices": [_device_name(state, token) for token in connected],
+        },
+        status=400,
+    )
+
+
+async def _handle_devices(request: web.Request, state: _RelayState) -> web.Response:
+    """Return configured devices and their connection state."""
+    async with state.phone_ws_lock:
+        connected = {token for token, ws in state.phone_ws.items() if not ws.closed}
+
+    devices = []
+    for token in sorted(state.pairing_codes):
+        devices.append(
+            {
+                "device": _device_name(state, token),
+                "token": _mask_token(token),
+                "connected": token in connected,
+                "default": token == state.default_device,
+            }
+        )
+    return web.json_response({"devices": devices})
 
 
 async def _handle_http(
     request: web.Request, state: _RelayState, path: str
 ) -> web.Response:
     """Forward an HTTP request from a tool to the phone over WebSocket."""
+    body = {}
+    if request.method == "POST":
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+
+    token, error_response = _resolve_requested_token(state, request, body)
+    if error_response is not None:
+        return error_response
+
     async with state.phone_ws_lock:
-        ws = state.phone_ws
+        ws = state.phone_ws.get(token) if token else None
         if ws is None or ws.closed:
             return web.json_response(
                 {
-                    "error": "No phone connected. Open the Hermes app on your phone and connect."
+                    "error": f"Android device '{_device_name(state, token or '')}' is not connected."
                 },
                 status=503,
             )
@@ -467,13 +616,8 @@ async def _handle_http(
     request_id = str(uuid.uuid4())
     method = request.method  # GET or POST
     params = dict(request.query)
-
-    body = {}
-    if method == "POST":
-        try:
-            body = await request.json()
-        except Exception:
-            body = {}
+    for key in ("device", "token", "target_device"):
+        params.pop(key, None)
 
     command = {
         "request_id": request_id,
@@ -487,7 +631,7 @@ async def _handle_http(
     # Register a future *before* sending so we never miss the reply
     future = state.loop.create_future()
     async with state.pending_lock:
-        state.pending[request_id] = future
+        state.pending[request_id] = (future, token)
 
     try:
         await ws.send_json(command)

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -514,7 +514,7 @@ _RESPONSE_TIMEOUT = 30  # seconds
 
 def _device_name(state: _RelayState, token: str) -> str:
     for alias, alias_token in state.device_aliases.items():
-        if alias_token == token:
+        if alias_token == token and _normalize_token(alias) == token:
             return alias
     return token
 

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -519,6 +519,15 @@ def _device_name(state: _RelayState, token: str) -> str:
     return token
 
 
+def _device_aliases(state: _RelayState, token: str) -> list[str]:
+    aliases = [
+        alias for alias, alias_token in state.device_aliases.items() if alias_token == token
+    ]
+    if token not in aliases:
+        aliases.append(token)
+    return aliases
+
+
 def _resolve_requested_token(
     state: _RelayState,
     request: web.Request,
@@ -579,6 +588,7 @@ async def _handle_devices(request: web.Request, state: _RelayState) -> web.Respo
         devices.append(
             {
                 "device": _device_name(state, token),
+                "aliases": _device_aliases(state, token),
                 "token": _mask_token(token),
                 "connected": token in connected,
                 "default": token == state.default_device,

--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -64,14 +64,16 @@ def _bridge_token() -> Optional[str]:
 _CURRENT_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "android_device", default=None
 )
-_ACTIVE_DEVICE: Optional[str] = None
+_ACTIVE_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "android_active_device", default=None
+)
 
 
 def _selected_device(device: Optional[str] = None) -> Optional[str]:
     return (
         device
         or _CURRENT_DEVICE.get()
-        or _ACTIVE_DEVICE
+        or _ACTIVE_DEVICE.get()
         or os.getenv("ANDROID_DEFAULT_DEVICE")
     )
 
@@ -178,9 +180,8 @@ def android_devices() -> str:
 def android_select_device(device: str) -> str:
     """
     Select the Android device that subsequent android_* tool calls should target.
-    Use a device alias from android_devices(), such as 'old' or 'lrw2u7'.
+    Use a device alias from android_devices(), such as 'phone-a' or 'lrw2u7'.
     """
-    global _ACTIVE_DEVICE
     try:
         requested = str(device).strip()
         if not requested:
@@ -202,13 +203,14 @@ def android_select_device(device: str) -> str:
                             "devices": devices,
                         }
                     )
-                _ACTIVE_DEVICE = item.get("device") or requested
+                _ACTIVE_DEVICE.set(requested)
                 return json.dumps(
                     {
                         "status": "ok",
-                        "active_device": _ACTIVE_DEVICE,
+                        "active_device": requested,
+                        "matched_device": item.get("device"),
                         "message": (
-                            f"Selected Android device '{_ACTIVE_DEVICE}'. "
+                            f"Selected Android device '{requested}'. "
                             "Subsequent android_* calls will target it unless a device argument is provided."
                         ),
                         "devices": devices,
@@ -979,7 +981,7 @@ _SCHEMAS = {
             "properties": {
                 "device": {
                     "type": "string",
-                    "description": "Device alias from android_devices, such as old, new, lrw2u7, or emdmfu.",
+                    "description": "Device alias from android_devices, such as phone-a, work, lrw2u7, or emdmfu.",
                 }
             },
             "required": ["device"],
@@ -1576,47 +1578,55 @@ def _with_target_device(args: dict, handler):
     finally:
         _CURRENT_DEVICE.reset(token)
 
+def _make_handler(func, *, target_device: bool = True, pass_args: bool = True):
+    def _call(call_args: dict):
+        return func(**call_args) if pass_args else func()
+
+    if not target_device:
+        return lambda args, **kw: _call(dict(args or {}))
+    return lambda args, **kw: _with_target_device(args, _call)
+
 _HANDLERS = {
-    "android_ping": lambda args, **kw: _with_target_device(args, lambda _args: android_ping()),
-    "android_devices": lambda args, **kw: android_devices(),
-    "android_select_device": lambda args, **kw: android_select_device(**args),
-    "android_read_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_read_screen(**call_args)),
-    "android_tap": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap(**call_args)),
-    "android_tap_text": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap_text(**call_args)),
-    "android_type": lambda args, **kw: _with_target_device(args, lambda call_args: android_type(**call_args)),
-    "android_swipe": lambda args, **kw: _with_target_device(args, lambda call_args: android_swipe(**call_args)),
-    "android_open_app": lambda args, **kw: _with_target_device(args, lambda call_args: android_open_app(**call_args)),
-    "android_press_key": lambda args, **kw: _with_target_device(args, lambda call_args: android_press_key(**call_args)),
-    "android_screenshot": lambda args, **kw: _with_target_device(args, lambda _args: android_screenshot()),
-    "android_scroll": lambda args, **kw: _with_target_device(args, lambda call_args: android_scroll(**call_args)),
-    "android_wait": lambda args, **kw: _with_target_device(args, lambda call_args: android_wait(**call_args)),
-    "android_get_apps": lambda args, **kw: _with_target_device(args, lambda _args: android_get_apps()),
-    "android_current_app": lambda args, **kw: _with_target_device(args, lambda _args: android_current_app()),
-    "android_setup": lambda args, **kw: android_setup(**args),
-    "android_clipboard_read": lambda args, **kw: _with_target_device(args, lambda _args: android_clipboard_read()),
-    "android_clipboard_write": lambda args, **kw: _with_target_device(args, lambda call_args: android_clipboard_write(**call_args)),
-    "android_notifications": lambda args, **kw: _with_target_device(args, lambda call_args: android_notifications(**call_args)),
-    "android_long_press": lambda args, **kw: _with_target_device(args, lambda call_args: android_long_press(**call_args)),
-    "android_drag": lambda args, **kw: _with_target_device(args, lambda call_args: android_drag(**call_args)),
-    "android_describe_node": lambda args, **kw: _with_target_device(args, lambda call_args: android_describe_node(**call_args)),
-    "android_screen_hash": lambda args, **kw: _with_target_device(args, lambda _args: android_screen_hash()),
-    "android_macro": lambda args, **kw: _with_target_device(args, lambda call_args: android_macro(**call_args)),
-    "android_location": lambda args, **kw: _with_target_device(args, lambda _args: android_location()),
-    "android_send_sms": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_sms(**call_args)),
-    "android_call": lambda args, **kw: _with_target_device(args, lambda call_args: android_call(**call_args)),
-    "android_speak": lambda args, **kw: _with_target_device(args, lambda call_args: android_speak(**call_args)),
-    "android_speak_stop": lambda args, **kw: _with_target_device(args, lambda _args: android_speak_stop()),
-    "android_events": lambda args, **kw: _with_target_device(args, lambda call_args: android_events(**call_args)),
-    "android_event_stream": lambda args, **kw: _with_target_device(args, lambda call_args: android_event_stream(**call_args)),
-    "android_screen_record": lambda args, **kw: _with_target_device(args, lambda call_args: android_screen_record(**call_args)),
-    "android_read_widgets": lambda args, **kw: _with_target_device(args, lambda _args: android_read_widgets()),
-    "android_find_nodes": lambda args, **kw: _with_target_device(args, lambda call_args: android_find_nodes(**call_args)),
-    "android_diff_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_diff_screen(**call_args)),
-    "android_pinch": lambda args, **kw: _with_target_device(args, lambda call_args: android_pinch(**call_args)),
-    "android_media": lambda args, **kw: _with_target_device(args, lambda call_args: android_media(**call_args)),
-    "android_search_contacts": lambda args, **kw: _with_target_device(args, lambda call_args: android_search_contacts(**call_args)),
-    "android_send_intent": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_intent(**call_args)),
-    "android_broadcast": lambda args, **kw: _with_target_device(args, lambda call_args: android_broadcast(**call_args)),
+    "android_ping": _make_handler(android_ping, pass_args=False),
+    "android_devices": _make_handler(android_devices, target_device=False, pass_args=False),
+    "android_select_device": _make_handler(android_select_device, target_device=False),
+    "android_read_screen": _make_handler(android_read_screen),
+    "android_tap": _make_handler(android_tap),
+    "android_tap_text": _make_handler(android_tap_text),
+    "android_type": _make_handler(android_type),
+    "android_swipe": _make_handler(android_swipe),
+    "android_open_app": _make_handler(android_open_app),
+    "android_press_key": _make_handler(android_press_key),
+    "android_screenshot": _make_handler(android_screenshot, pass_args=False),
+    "android_scroll": _make_handler(android_scroll),
+    "android_wait": _make_handler(android_wait),
+    "android_get_apps": _make_handler(android_get_apps, pass_args=False),
+    "android_current_app": _make_handler(android_current_app, pass_args=False),
+    "android_setup": _make_handler(android_setup, target_device=False),
+    "android_clipboard_read": _make_handler(android_clipboard_read, pass_args=False),
+    "android_clipboard_write": _make_handler(android_clipboard_write),
+    "android_notifications": _make_handler(android_notifications),
+    "android_long_press": _make_handler(android_long_press),
+    "android_drag": _make_handler(android_drag),
+    "android_describe_node": _make_handler(android_describe_node),
+    "android_screen_hash": _make_handler(android_screen_hash, pass_args=False),
+    "android_macro": _make_handler(android_macro),
+    "android_location": _make_handler(android_location, pass_args=False),
+    "android_send_sms": _make_handler(android_send_sms),
+    "android_call": _make_handler(android_call),
+    "android_speak": _make_handler(android_speak),
+    "android_speak_stop": _make_handler(android_speak_stop, pass_args=False),
+    "android_events": _make_handler(android_events),
+    "android_event_stream": _make_handler(android_event_stream),
+    "android_screen_record": _make_handler(android_screen_record),
+    "android_read_widgets": _make_handler(android_read_widgets, pass_args=False),
+    "android_find_nodes": _make_handler(android_find_nodes),
+    "android_diff_screen": _make_handler(android_diff_screen),
+    "android_pinch": _make_handler(android_pinch),
+    "android_media": _make_handler(android_media),
+    "android_search_contacts": _make_handler(android_search_contacts),
+    "android_send_intent": _make_handler(android_send_intent),
+    "android_broadcast": _make_handler(android_broadcast),
 }
 
 # ── Registry registration ──────────────────────────────────────────────────────

--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -36,9 +36,10 @@ Tools registered:
 import json
 import os
 import time
+import contextvars
 import requests
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 # ── Config ────────────────────────────────────────────────────────────────────
 #
@@ -58,6 +59,15 @@ def _bridge_url() -> str:
 
 def _bridge_token() -> Optional[str]:
     return os.getenv("ANDROID_BRIDGE_TOKEN")
+
+
+_CURRENT_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "android_device", default=None
+)
+
+
+def _selected_device(device: Optional[str] = None) -> Optional[str]:
+    return device or _CURRENT_DEVICE.get() or os.getenv("ANDROID_DEFAULT_DEVICE")
 
 
 def _relay_port() -> int:
@@ -106,9 +116,17 @@ def _extract_response(r: requests.Response) -> dict:
     return body
 
 
-def _post(path: str, payload: dict) -> dict:
+def _with_device(path: str, device: Optional[str] = None) -> str:
+    selected = _selected_device(device)
+    if not selected or path.startswith("/devices"):
+        return path
+    separator = "&" if "?" in path else "?"
+    return f"{path}{separator}{urlencode({'device': selected})}"
+
+
+def _post(path: str, payload: dict, device: Optional[str] = None) -> dict:
     r = requests.post(
-        f"{_bridge_url()}{path}",
+        f"{_bridge_url()}{_with_device(path, device)}",
         json=payload,
         headers=_auth_headers(),
         timeout=_timeout(),
@@ -116,9 +134,11 @@ def _post(path: str, payload: dict) -> dict:
     return _extract_response(r)
 
 
-def _get(path: str) -> dict:
+def _get(path: str, device: Optional[str] = None) -> dict:
     r = requests.get(
-        f"{_bridge_url()}{path}", headers=_auth_headers(), timeout=_timeout()
+        f"{_bridge_url()}{_with_device(path, device)}",
+        headers=_auth_headers(),
+        timeout=_timeout(),
     )
     return _extract_response(r)
 
@@ -132,6 +152,15 @@ def android_ping() -> str:
         return json.dumps({"status": "ok", "bridge": data})
     except Exception as e:
         return json.dumps({"status": "error", "message": str(e)})
+
+
+def android_devices() -> str:
+    """List configured Android devices and whether each one is connected."""
+    try:
+        data = _get("/devices")
+        return json.dumps(data)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
 
 
 def android_read_screen(include_bounds: bool = False) -> str:
@@ -763,6 +792,12 @@ def android_setup(pairing_code: str) -> str:
     try:
         port = _relay_port()
         public_ip = _get_public_ip()
+        pairing_codes = [
+            code.strip().upper()
+            for code in pairing_code.replace(";", ",").split(",")
+            if code.strip()
+        ]
+        bridge_token = pairing_codes[0] if pairing_codes else pairing_code
 
         # Save config to ~/.hermes/.env
         relay_url = f"http://localhost:{port}"
@@ -770,7 +805,8 @@ def android_setup(pairing_code: str) -> str:
             from hermes_cli.config import save_env_value
 
             save_env_value("ANDROID_BRIDGE_URL", relay_url)
-            save_env_value("ANDROID_BRIDGE_TOKEN", pairing_code)
+            save_env_value("ANDROID_BRIDGE_TOKEN", bridge_token)
+            save_env_value("ANDROID_BRIDGE_TOKENS", ",".join(pairing_codes))
             save_env_value("ANDROID_RELAY_PORT", str(port))
         except ImportError:
             from pathlib import Path
@@ -778,12 +814,14 @@ def android_setup(pairing_code: str) -> str:
             env_path = Path.home() / ".hermes" / ".env"
             env_path.parent.mkdir(parents=True, exist_ok=True)
             _update_env_file(env_path, "ANDROID_BRIDGE_URL", relay_url)
-            _update_env_file(env_path, "ANDROID_BRIDGE_TOKEN", pairing_code)
+            _update_env_file(env_path, "ANDROID_BRIDGE_TOKEN", bridge_token)
+            _update_env_file(env_path, "ANDROID_BRIDGE_TOKENS", ",".join(pairing_codes))
             _update_env_file(env_path, "ANDROID_RELAY_PORT", str(port))
 
         # Update current process env
         os.environ["ANDROID_BRIDGE_URL"] = relay_url
-        os.environ["ANDROID_BRIDGE_TOKEN"] = pairing_code
+        os.environ["ANDROID_BRIDGE_TOKEN"] = bridge_token
+        os.environ["ANDROID_BRIDGE_TOKENS"] = ",".join(pairing_codes)
 
         # Start the relay server
         try:
@@ -860,6 +898,11 @@ _SCHEMAS = {
     "android_ping": {
         "name": "android_ping",
         "description": "Check if the Android bridge is reachable. Call this first before any other android_ tools.",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_devices": {
+        "name": "android_devices",
+        "description": "List configured Android devices and whether each device is connected. Use this before targeting a specific device.",
         "parameters": {"type": "object", "properties": {}, "required": []},
     },
     "android_read_screen": {
@@ -1430,47 +1473,69 @@ _SCHEMAS = {
     },
 }
 
+_DEVICE_PARAMETER = {
+    "type": "string",
+    "description": "Optional Android device alias or pairing token to target when multiple devices are connected.",
+}
+
+for _tool_name, _schema in _SCHEMAS.items():
+    if _tool_name in {"android_setup", "android_devices"}:
+        continue
+    _schema["parameters"].setdefault("properties", {})["device"] = _DEVICE_PARAMETER
+
+
 # ── Tool handlers map ──────────────────────────────────────────────────────────
 
+
+def _with_target_device(args: dict, handler):
+    call_args = dict(args or {})
+    device = call_args.pop("device", None)
+    token = _CURRENT_DEVICE.set(device)
+    try:
+        return handler(call_args)
+    finally:
+        _CURRENT_DEVICE.reset(token)
+
 _HANDLERS = {
-    "android_ping": lambda args, **kw: android_ping(),
-    "android_read_screen": lambda args, **kw: android_read_screen(**args),
-    "android_tap": lambda args, **kw: android_tap(**args),
-    "android_tap_text": lambda args, **kw: android_tap_text(**args),
-    "android_type": lambda args, **kw: android_type(**args),
-    "android_swipe": lambda args, **kw: android_swipe(**args),
-    "android_open_app": lambda args, **kw: android_open_app(**args),
-    "android_press_key": lambda args, **kw: android_press_key(**args),
-    "android_screenshot": lambda args, **kw: android_screenshot(),
-    "android_scroll": lambda args, **kw: android_scroll(**args),
-    "android_wait": lambda args, **kw: android_wait(**args),
-    "android_get_apps": lambda args, **kw: android_get_apps(),
-    "android_current_app": lambda args, **kw: android_current_app(),
+    "android_ping": lambda args, **kw: _with_target_device(args, lambda _args: android_ping()),
+    "android_devices": lambda args, **kw: android_devices(),
+    "android_read_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_read_screen(**call_args)),
+    "android_tap": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap(**call_args)),
+    "android_tap_text": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap_text(**call_args)),
+    "android_type": lambda args, **kw: _with_target_device(args, lambda call_args: android_type(**call_args)),
+    "android_swipe": lambda args, **kw: _with_target_device(args, lambda call_args: android_swipe(**call_args)),
+    "android_open_app": lambda args, **kw: _with_target_device(args, lambda call_args: android_open_app(**call_args)),
+    "android_press_key": lambda args, **kw: _with_target_device(args, lambda call_args: android_press_key(**call_args)),
+    "android_screenshot": lambda args, **kw: _with_target_device(args, lambda _args: android_screenshot()),
+    "android_scroll": lambda args, **kw: _with_target_device(args, lambda call_args: android_scroll(**call_args)),
+    "android_wait": lambda args, **kw: _with_target_device(args, lambda call_args: android_wait(**call_args)),
+    "android_get_apps": lambda args, **kw: _with_target_device(args, lambda _args: android_get_apps()),
+    "android_current_app": lambda args, **kw: _with_target_device(args, lambda _args: android_current_app()),
     "android_setup": lambda args, **kw: android_setup(**args),
-    "android_clipboard_read": lambda args, **kw: android_clipboard_read(),
-    "android_clipboard_write": lambda args, **kw: android_clipboard_write(**args),
-    "android_notifications": lambda args, **kw: android_notifications(**args),
-    "android_long_press": lambda args, **kw: android_long_press(**args),
-    "android_drag": lambda args, **kw: android_drag(**args),
-    "android_describe_node": lambda args, **kw: android_describe_node(**args),
-    "android_screen_hash": lambda args, **kw: android_screen_hash(),
-    "android_macro": lambda args, **kw: android_macro(**args),
-    "android_location": lambda args, **kw: android_location(),
-    "android_send_sms": lambda args, **kw: android_send_sms(**args),
-    "android_call": lambda args, **kw: android_call(**args),
-    "android_speak": lambda args, **kw: android_speak(**args),
-    "android_speak_stop": lambda args, **kw: android_speak_stop(),
-    "android_events": lambda args, **kw: android_events(**args),
-    "android_event_stream": lambda args, **kw: android_event_stream(**args),
-    "android_screen_record": lambda args, **kw: android_screen_record(**args),
-    "android_read_widgets": lambda args, **kw: android_read_widgets(),
-    "android_find_nodes": lambda args, **kw: android_find_nodes(**args),
-    "android_diff_screen": lambda args, **kw: android_diff_screen(**args),
-    "android_pinch": lambda args, **kw: android_pinch(**args),
-    "android_media": lambda args, **kw: android_media(**args),
-    "android_search_contacts": lambda args, **kw: android_search_contacts(**args),
-    "android_send_intent": lambda args, **kw: android_send_intent(**args),
-    "android_broadcast": lambda args, **kw: android_broadcast(**args),
+    "android_clipboard_read": lambda args, **kw: _with_target_device(args, lambda _args: android_clipboard_read()),
+    "android_clipboard_write": lambda args, **kw: _with_target_device(args, lambda call_args: android_clipboard_write(**call_args)),
+    "android_notifications": lambda args, **kw: _with_target_device(args, lambda call_args: android_notifications(**call_args)),
+    "android_long_press": lambda args, **kw: _with_target_device(args, lambda call_args: android_long_press(**call_args)),
+    "android_drag": lambda args, **kw: _with_target_device(args, lambda call_args: android_drag(**call_args)),
+    "android_describe_node": lambda args, **kw: _with_target_device(args, lambda call_args: android_describe_node(**call_args)),
+    "android_screen_hash": lambda args, **kw: _with_target_device(args, lambda _args: android_screen_hash()),
+    "android_macro": lambda args, **kw: _with_target_device(args, lambda call_args: android_macro(**call_args)),
+    "android_location": lambda args, **kw: _with_target_device(args, lambda _args: android_location()),
+    "android_send_sms": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_sms(**call_args)),
+    "android_call": lambda args, **kw: _with_target_device(args, lambda call_args: android_call(**call_args)),
+    "android_speak": lambda args, **kw: _with_target_device(args, lambda call_args: android_speak(**call_args)),
+    "android_speak_stop": lambda args, **kw: _with_target_device(args, lambda _args: android_speak_stop()),
+    "android_events": lambda args, **kw: _with_target_device(args, lambda call_args: android_events(**call_args)),
+    "android_event_stream": lambda args, **kw: _with_target_device(args, lambda call_args: android_event_stream(**call_args)),
+    "android_screen_record": lambda args, **kw: _with_target_device(args, lambda call_args: android_screen_record(**call_args)),
+    "android_read_widgets": lambda args, **kw: _with_target_device(args, lambda _args: android_read_widgets()),
+    "android_find_nodes": lambda args, **kw: _with_target_device(args, lambda call_args: android_find_nodes(**call_args)),
+    "android_diff_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_diff_screen(**call_args)),
+    "android_pinch": lambda args, **kw: _with_target_device(args, lambda call_args: android_pinch(**call_args)),
+    "android_media": lambda args, **kw: _with_target_device(args, lambda call_args: android_media(**call_args)),
+    "android_search_contacts": lambda args, **kw: _with_target_device(args, lambda call_args: android_search_contacts(**call_args)),
+    "android_send_intent": lambda args, **kw: _with_target_device(args, lambda call_args: android_send_intent(**call_args)),
+    "android_broadcast": lambda args, **kw: _with_target_device(args, lambda call_args: android_broadcast(**call_args)),
 }
 
 # ── Registry registration ──────────────────────────────────────────────────────

--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -64,10 +64,16 @@ def _bridge_token() -> Optional[str]:
 _CURRENT_DEVICE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "android_device", default=None
 )
+_ACTIVE_DEVICE: Optional[str] = None
 
 
 def _selected_device(device: Optional[str] = None) -> Optional[str]:
-    return device or _CURRENT_DEVICE.get() or os.getenv("ANDROID_DEFAULT_DEVICE")
+    return (
+        device
+        or _CURRENT_DEVICE.get()
+        or _ACTIVE_DEVICE
+        or os.getenv("ANDROID_DEFAULT_DEVICE")
+    )
 
 
 def _relay_port() -> int:
@@ -158,7 +164,67 @@ def android_devices() -> str:
     """List configured Android devices and whether each one is connected."""
     try:
         data = _get("/devices")
+        data["active_device"] = _selected_device()
+        data["usage"] = (
+            "Use android_select_device(device) before a multi-step task, or pass "
+            "device to individual android_* calls. Call android_read_screen after "
+            "selecting a device before tapping."
+        )
         return json.dumps(data)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_select_device(device: str) -> str:
+    """
+    Select the Android device that subsequent android_* tool calls should target.
+    Use a device alias from android_devices(), such as 'old' or 'lrw2u7'.
+    """
+    global _ACTIVE_DEVICE
+    try:
+        requested = str(device).strip()
+        if not requested:
+            return json.dumps({"error": "device is required"})
+
+        data = _get("/devices")
+        devices = data.get("devices", [])
+        connected = []
+        for item in devices:
+            aliases = [item.get("device"), *item.get("aliases", [])]
+            aliases = [str(alias) for alias in aliases if alias]
+            if item.get("connected"):
+                connected.append(item.get("device"))
+            if requested.lower() in {alias.lower() for alias in aliases}:
+                if not item.get("connected"):
+                    return json.dumps(
+                        {
+                            "error": f"Android device '{requested}' is configured but not connected.",
+                            "devices": devices,
+                        }
+                    )
+                _ACTIVE_DEVICE = item.get("device") or requested
+                return json.dumps(
+                    {
+                        "status": "ok",
+                        "active_device": _ACTIVE_DEVICE,
+                        "message": (
+                            f"Selected Android device '{_ACTIVE_DEVICE}'. "
+                            "Subsequent android_* calls will target it unless a device argument is provided."
+                        ),
+                        "devices": devices,
+                    }
+                )
+
+        return json.dumps(
+            {
+                "error": (
+                    f"Unknown Android device '{requested}'. Call android_devices and choose "
+                    "one of the listed device names or aliases."
+                ),
+                "connected_devices": connected,
+                "devices": devices,
+            }
+        )
     except Exception as e:
         return json.dumps({"error": str(e)})
 
@@ -902,8 +968,22 @@ _SCHEMAS = {
     },
     "android_devices": {
         "name": "android_devices",
-        "description": "List configured Android devices and whether each device is connected. Use this before targeting a specific device.",
+        "description": "List configured Android devices, aliases, connection state, and the currently selected target device. Use this before choosing a device.",
         "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_select_device": {
+        "name": "android_select_device",
+        "description": "Select which Android device subsequent android_* calls should target. Call android_devices first when the user refers to a phone ambiguously. After selecting, call android_read_screen before tapping.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "device": {
+                    "type": "string",
+                    "description": "Device alias from android_devices, such as old, new, lrw2u7, or emdmfu.",
+                }
+            },
+            "required": ["device"],
+        },
     },
     "android_read_screen": {
         "name": "android_read_screen",
@@ -1479,7 +1559,7 @@ _DEVICE_PARAMETER = {
 }
 
 for _tool_name, _schema in _SCHEMAS.items():
-    if _tool_name in {"android_setup", "android_devices"}:
+    if _tool_name in {"android_setup", "android_devices", "android_select_device"}:
         continue
     _schema["parameters"].setdefault("properties", {})["device"] = _DEVICE_PARAMETER
 
@@ -1499,6 +1579,7 @@ def _with_target_device(args: dict, handler):
 _HANDLERS = {
     "android_ping": lambda args, **kw: _with_target_device(args, lambda _args: android_ping()),
     "android_devices": lambda args, **kw: android_devices(),
+    "android_select_device": lambda args, **kw: android_select_device(**args),
     "android_read_screen": lambda args, **kw: _with_target_device(args, lambda call_args: android_read_screen(**call_args)),
     "android_tap": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap(**call_args)),
     "android_tap_text": lambda args, **kw: _with_target_device(args, lambda call_args: android_tap_text(**call_args)),


### PR DESCRIPTION
## 概要
- relay が複数の pairing token を受け付け、token ごとに WebSocket 接続を保持できるようにしました。
- `/devices` endpoint と `device` 指定を追加し、複数端末接続時に対象端末を明示して操作できるようにしました。
- `android_devices` tool と各 android tool schema の `device` parameter を追加しました。

## 背景
従来の relay は単一の `phone_ws` だけを持つため、別 token の端末が接続すると拒否されるか、同じ token の再接続として既存接続を置き換える構造でした。複数端末を Hermes から一括管理するには、token/device 単位で接続と pending request を分離する必要があります。

## 検証
- `python3 -m py_compile tools/android_relay.py tools/android_tool.py hermes-android-plugin/android_relay.py hermes-android-plugin/android_tool.py`
- `. .venv/bin/activate && python -m pytest tests/test_android_relay.py tests/test_android_tool.py`
  - 125 passed

## 補足
- 既存の単一端末構成は、接続端末が1台だけの場合は従来通り device 指定なしで動作します。
- 複数端末が接続されている場合は `device` alias または pairing token を指定できます。
