### PR TITLE
auto: recycle focusedNode in typeText() to prevent memory leak

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -104,28 +104,32 @@ object ActionExecutor {
 
         val focusedNode = service.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
 
-        if (clearFirst) {
-            val bundle = Bundle()
-            bundle.putInt(
-                AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_START_INT, 0
-            )
-            bundle.putInt(
-                AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_END_INT,
-                focusedNode?.text?.length ?: 0
-            )
-            focusedNode?.performAction(AccessibilityNodeInfo.ACTION_SET_SELECTION, bundle)
-            focusedNode?.performAction(AccessibilityNodeInfo.ACTION_CUT)
-        }
+        try {
+            if (clearFirst) {
+                val bundle = Bundle()
+                bundle.putInt(
+                    AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_START_INT, 0
+                )
+                bundle.putInt(
+                    AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_END_INT,
+                    focusedNode?.text?.length ?: 0
+                )
+                focusedNode?.performAction(AccessibilityNodeInfo.ACTION_SET_SELECTION, bundle)
+                focusedNode?.performAction(AccessibilityNodeInfo.ACTION_CUT)
+            }
 
-        val arguments = Bundle().apply {
-            putCharSequence(
-                AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text
-            )
+            val arguments = Bundle().apply {
+                putCharSequence(
+                    AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text
+                )
+            }
+            val result = focusedNode?.performAction(
+                AccessibilityNodeInfo.ACTION_SET_TEXT, arguments
+            ) ?: false
+            ActionResult(result, if (result) "Typed text" else "No focused input found")
+        } finally {
+            focusedNode?.recycle()
         }
-        val result = focusedNode?.performAction(
-            AccessibilityNodeInfo.ACTION_SET_TEXT, arguments
-        ) ?: false
-        ActionResult(result, if (result) "Typed text" else "No focused input found")
     }
 
     suspend fun swipe(direction: String, distance: String = "medium"): ActionResult =


### PR DESCRIPTION
## Fix

Recycles the `focusedNode` accessibility node after use in `typeText()` to prevent memory leaks from unreleased node references.

## Changes
- Wraps `typeText()` in try/finally to ensure `focusedNode.recycle()` is always called
- Prevents AccessibilityNodeInfo leak on error paths

Auto-generated PR from auto-fix pipeline.