### PR TITLE
fix(security): mask pairing token in log output

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
@@ -102,8 +102,8 @@ object RelayClient {
 
     private fun doConnect(serverUrl: String, pairingCode: String) {
         val wsUrl = buildWsUrl(serverUrl, pairingCode)
-        Log.i(TAG, "Connecting to $wsUrl")
-        notifyStatus(false, "Connecting to $wsUrl ...")
+        Log.i(TAG, "Connecting to ${buildWsUrl(serverUrl, "***")}")
+        notifyStatus(false, "Connecting to ${buildWsUrl(serverUrl, "***")} ...")
 
         val request = Request.Builder()
             .url(wsUrl)
@@ -112,7 +112,7 @@ object RelayClient {
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
 
             override fun onOpen(webSocket: WebSocket, response: Response) {
-                Log.i(TAG, "WebSocket connected to $wsUrl")
+                Log.i(TAG, "WebSocket connected to ${buildWsUrl(serverUrl, "***")}")
                 isConnected = true
                 try {
                     BridgeAccessibilityService.instance?.startForeground()


### PR DESCRIPTION
## Summary

Masks the pairing token in log output to prevent credential leakage.

## Changes
- `RelayClient.kt`: Token values are now masked/redacted in log statements instead of printed in plaintext

## Why
Logging authentication tokens in plaintext is a security risk — they can appear in logcat, crash reporters, and CI logs.

## Testing
- Single-file change, 3 lines modified
- Log output verified to show masked token instead of raw value

Auto-generated by PR pipeline.