### PR TITLE
fix: TLS warning on non-loopback bind, guard debug logs, clamp searchContacts limit

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
@@ -15,7 +15,6 @@ import com.hermesandroid.bridge.event.EventStore
 import com.hermesandroid.bridge.notification.NotificationStore
 import com.hermesandroid.bridge.service.BridgeAccessibilityService
 import com.hermesandroid.bridge.service.BridgeNotificationListener
-import com.hermesandroid.bridge.BuildConfig
 import kotlinx.coroutines.*
 import okhttp3.*
 

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
@@ -3,6 +3,7 @@ package com.hermesandroid.bridge.client
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import com.hermesandroid.bridge.BuildConfig
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
@@ -206,7 +207,7 @@ object RelayClient {
             val params = json.getAsJsonObject("params") ?: JsonObject()
             val body = json.getAsJsonObject("body") ?: JsonObject()
 
-            Log.d(TAG, "Received command: $method $path (id=$requestId)")
+            if (BuildConfig.DEBUG) Log.d(TAG, "Received command: $method $path (id=$requestId)")
 
             val response = dispatchCommand(method, path, params, body)
 

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -568,6 +568,7 @@ object ActionExecutor {
     }
 
     fun searchContacts(query: String, limit: Int = 20): ActionResult {
+        val safeLimit = limit.coerceAtMost(100).coerceAtLeast(1)
         val service = BridgeAccessibilityService.instance
             ?: return ActionResult(false, "Accessibility service not running")
         if (!service.hasSelfPermission(android.Manifest.permission.READ_CONTACTS)) {
@@ -580,7 +581,7 @@ object ActionExecutor {
                 android.provider.ContactsContract.Contacts._ID,
                 android.provider.ContactsContract.Contacts.DISPLAY_NAME
             )
-            val cursor = service.contentResolver.query(uri, projection, null, null, "${android.provider.ContactsContract.Contacts.DISPLAY_NAME} ASC LIMIT $limit")
+            val cursor = service.contentResolver.query(uri, projection, null, null, "${android.provider.ContactsContract.Contacts.DISPLAY_NAME} ASC LIMIT $safeLimit")
             cursor?.use {
                 val idIdx = it.getColumnIndex(android.provider.ContactsContract.Contacts._ID)
                 val nameIdx = it.getColumnIndex(android.provider.ContactsContract.Contacts.DISPLAY_NAME)

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeNotificationListener.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeNotificationListener.kt
@@ -7,6 +7,7 @@ import android.content.IntentFilter
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import android.util.Log
+import com.hermesandroid.bridge.BuildConfig
 import com.hermesandroid.bridge.notification.NotificationStore
 
 class BridgeNotificationListener : NotificationListenerService() {
@@ -30,7 +31,7 @@ class BridgeNotificationListener : NotificationListenerService() {
         val entry = NotificationStore.parseNotification(sbn)
         if (entry != null) {
             NotificationStore.add(entry)
-            Log.d(TAG, "Notification from ${entry.packageName}: ${entry.text?.take(50)}")
+            if (BuildConfig.DEBUG) Log.d(TAG, "Notification from ${entry.packageName}: ${entry.text?.take(50)}")
         }
     }
 

--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -254,6 +254,14 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
 
     scheme = "https" if ssl_ctx else "http"
     logger.info("Relay listening on %s://0.0.0.0:%d", scheme, state.port)
+
+    if not ssl_ctx:
+        logger.warning(
+            "⚠️  TLS is NOT configured — all traffic (including pairing tokens) is "
+            "sent in cleartext. Set ANDROID_RELAY_CERT and ANDROID_RELAY_KEY env vars "
+            "to enable TLS. Binding to 0.0.0.0 without TLS is insecure for internet-facing use."
+        )
+
     ready.set()
 
     # Block until shutdown is signalled

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -258,6 +258,13 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
 
     scheme = "https" if ssl_ctx else "http"
     logger.info("Relay listening on %s://0.0.0.0:%d", scheme, state.port)
+
+    if not ssl_ctx:
+        logger.warning(
+            "⚠️  TLS is NOT configured — all traffic (including pairing tokens) is "
+            "sent in cleartext. Set ANDROID_RELAY_CERT and ANDROID_RELAY_KEY env vars "
+            "to enable TLS. Binding to 0.0.0.0 without TLS is insecure for internet-facing use."
+        )
     ready.set()
 
     # Block until shutdown is signalled


### PR DESCRIPTION
## Summary

Three security/hardening fixes in one branch:

1. **TLS warning on relay start** — When TLS is not configured, the Python relay now logs a prominent warning that traffic (including pairing tokens) is being sent in cleartext. Applies to both `hermes-android-plugin/android_relay.py` and `tools/android_relay.py`.

2. **Guard debug logs behind BuildConfig.DEBUG** — `RelayClient` and `BridgeNotificationListener` were logging command details and notification text unconditionally in release builds. Now gated behind `BuildConfig.DEBUG`.

3. **Clamp searchContacts limit** — The `limit` parameter in `ActionExecutor.searchContacts()` is now clamped to `\[1, 100\]` to prevent unbounded queries.

### Files changed
- `RelayClient.kt` — debug-log guard
- `ActionExecutor.kt` — searchContacts limit clamp
- `BridgeNotificationListener.kt` — debug-log guard
- `android_relay.py` (both copies) — TLS warning