### PR TITLE
docs+build: rename prebuilt APK to hermes-android.apk and document the download

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,21 @@ Restart hermes — run `/plugins` to verify. Should show: `✓ hermes-android v0
 
 ### 1. Install the bridge app on your phone
 
-Build with Android Studio or from command line:
+**Option A — Download the prebuilt APK (easiest).** Every push to `main` automatically
+publishes a fresh debug APK to the [**Latest Build**](https://github.com/raulvidis/hermes-android/releases/tag/latest-build)
+release. Download `app-debug.apk` from there and install it — either by opening the file
+on the device (enable "Install unknown apps" for your browser/file manager when prompted)
+or via `adb install app-debug.apk`.
+
+**Option B — Build from source:**
 ```bash
 cd hermes-android-bridge
 ./gradlew assembleDebug
 adb install app/build/outputs/apk/debug/app-debug.apk
 ```
+
+> The APK is an unsigned **debug** build, which is why Android/Play Protect may warn on
+> install — it is not yet published on the Play Store or F-Droid.
 
 ### 2. Grant permissions on the phone
 - Open Hermes Bridge app
@@ -78,8 +87,8 @@ The bridge app can run on Android Automotive OS (AAOS) car head units. Phone-spe
 
 ### Installation
 
-1. Build the APK: `cd hermes-android-bridge && ./gradlew assembleDebug`
-2. Sideload via ADB: `adb install app/build/outputs/apk/debug/app-debug.apk`
+1. Get the APK: download `app-debug.apk` from the [Latest Build release](https://github.com/raulvidis/hermes-android/releases/tag/latest-build), or build it with `cd hermes-android-bridge && ./gradlew assembleDebug`
+2. Sideload via ADB: `adb install app-debug.apk`
    - USB: connect directly to the head unit's USB port
    - WiFi: `adb connect <head-unit-ip>:5555` then install
 3. Grant Accessibility Service: **Settings > Accessibility > Hermes Bridge > Enable**

--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ Restart hermes — run `/plugins` to verify. Should show: `✓ hermes-android v0
 
 **Option A — Download the prebuilt APK (easiest).** Every push to `main` automatically
 publishes a fresh debug APK to the [**Latest Build**](https://github.com/raulvidis/hermes-android/releases/tag/latest-build)
-release. Download `hermes-android.apk` from there and install it — either by opening the file
-on the device (enable "Install unknown apps" for your browser/file manager when prompted)
-or via `adb install hermes-android.apk`.
+release. Download the `hermes-android-<version>.apk` asset from there and install it — either
+by opening the file on the device (enable "Install unknown apps" for your browser/file
+manager when prompted) or via `adb install hermes-android-*.apk`.
 
 **Option B — Build from source:**
 ```bash
 cd hermes-android-bridge
 ./gradlew assembleDebug
-adb install app/build/outputs/apk/debug/hermes-android.apk
+adb install app/build/outputs/apk/debug/hermes-android-*.apk
 ```
 
 > The APK is an unsigned **debug** build, which is why Android/Play Protect may warn on
@@ -87,8 +87,8 @@ The bridge app can run on Android Automotive OS (AAOS) car head units. Phone-spe
 
 ### Installation
 
-1. Get the APK: download `hermes-android.apk` from the [Latest Build release](https://github.com/raulvidis/hermes-android/releases/tag/latest-build), or build it with `cd hermes-android-bridge && ./gradlew assembleDebug`
-2. Sideload via ADB: `adb install hermes-android.apk`
+1. Get the APK: download `hermes-android-<version>.apk` from the [Latest Build release](https://github.com/raulvidis/hermes-android/releases/tag/latest-build), or build it with `cd hermes-android-bridge && ./gradlew assembleDebug`
+2. Sideload via ADB: `adb install hermes-android-*.apk`
    - USB: connect directly to the head unit's USB port
    - WiFi: `adb connect <head-unit-ip>:5555` then install
 3. Grant Accessibility Service: **Settings > Accessibility > Hermes Bridge > Enable**

--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ Restart hermes — run `/plugins` to verify. Should show: `✓ hermes-android v0
 
 **Option A — Download the prebuilt APK (easiest).** Every push to `main` automatically
 publishes a fresh debug APK to the [**Latest Build**](https://github.com/raulvidis/hermes-android/releases/tag/latest-build)
-release. Download `app-debug.apk` from there and install it — either by opening the file
+release. Download `hermes-android.apk` from there and install it — either by opening the file
 on the device (enable "Install unknown apps" for your browser/file manager when prompted)
-or via `adb install app-debug.apk`.
+or via `adb install hermes-android.apk`.
 
 **Option B — Build from source:**
 ```bash
 cd hermes-android-bridge
 ./gradlew assembleDebug
-adb install app/build/outputs/apk/debug/app-debug.apk
+adb install app/build/outputs/apk/debug/hermes-android.apk
 ```
 
 > The APK is an unsigned **debug** build, which is why Android/Play Protect may warn on
@@ -87,8 +87,8 @@ The bridge app can run on Android Automotive OS (AAOS) car head units. Phone-spe
 
 ### Installation
 
-1. Get the APK: download `app-debug.apk` from the [Latest Build release](https://github.com/raulvidis/hermes-android/releases/tag/latest-build), or build it with `cd hermes-android-bridge && ./gradlew assembleDebug`
-2. Sideload via ADB: `adb install app-debug.apk`
+1. Get the APK: download `hermes-android.apk` from the [Latest Build release](https://github.com/raulvidis/hermes-android/releases/tag/latest-build), or build it with `cd hermes-android-bridge && ./gradlew assembleDebug`
+2. Sideload via ADB: `adb install hermes-android.apk`
    - USB: connect directly to the head unit's USB port
    - WiFi: `adb connect <head-unit-ip>:5555` then install
 3. Grant Accessibility Service: **Settings > Accessibility > Hermes Bridge > Enable**

--- a/hermes-android-bridge/app/build.gradle.kts
+++ b/hermes-android-bridge/app/build.gradle.kts
@@ -25,12 +25,13 @@ android {
         }
     }
 
-    // Name the built APK `hermes-android.apk` instead of the default `app-debug.apk`,
-    // for local builds, the CI artifact, and the Latest Build release asset alike.
+    // Name the built APK `hermes-android-<version>.apk` instead of the default
+    // `app-debug.apk`, for local builds, the CI artifact, and the release asset alike.
     applicationVariants.all {
+        val variant = this
         outputs.all {
             (this as com.android.build.gradle.internal.api.BaseVariantOutputImpl)
-                .outputFileName = "hermes-android.apk"
+                .outputFileName = "hermes-android-${variant.versionName}.apk"
         }
     }
 

--- a/hermes-android-bridge/app/build.gradle.kts
+++ b/hermes-android-bridge/app/build.gradle.kts
@@ -25,6 +25,15 @@ android {
         }
     }
 
+    // Name the built APK `hermes-android.apk` instead of the default `app-debug.apk`,
+    // for local builds, the CI artifact, and the Latest Build release asset alike.
+    applicationVariants.all {
+        outputs.all {
+            (this as com.android.build.gradle.internal.api.BaseVariantOutputImpl)
+                .outputFileName = "hermes-android.apk"
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
Addresses #21 — clarifies that ADB is not the only install path, and gives the downloadable APK a recognizable name.

**Build:** sets the APK output filename to `hermes-android.apk` (via `applicationVariants`) so local builds, the CI artifact, and the [`latest-build` release](https://github.com/raulvidis/hermes-android/releases/tag/latest-build) asset are all named `hermes-android.apk` instead of `app-debug.apk`.

**Docs:** the README only documented building from source + `adb install`. Adds the prebuilt APK as the primary install option in both the Quick Start and AAOS sections, using the new filename, and notes it's an unsigned **debug** build (hence the install warning; not yet on Play Store / F-Droid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)