### PR TITLE
auto: shutdown TextToSpeech when accessibility service is destroyed

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -793,6 +793,12 @@ object ActionExecutor {
         return ActionResult(true, "Stopped speaking")
     }
 
+    fun shutdownTts() {
+        tts?.shutdown()
+        tts = null
+        ttsReady = false
+    }
+
     private fun Context.hasSelfPermission(permission: String): Boolean {
         return android.content.pm.PackageManager.PERMISSION_GRANTED ==
             checkSelfPermission(permission)

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeAccessibilityService.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeAccessibilityService.kt
@@ -112,6 +112,7 @@ class BridgeAccessibilityService : AccessibilityService() {
     }
 
     override fun onDestroy() {
+        com.hermesandroid.bridge.executor.ActionExecutor.shutdownTts()
         instance = null
         super.onDestroy()
     }


### PR DESCRIPTION
## Fix
TextToSpeech instance in ActionExecutor singleton was never shut down, leaking native resources.

## Changes
- Added `shutdownTts()` method to ActionExecutor that calls `tts?.shutdown()` and resets state
- Called from `BridgeAccessibilityService.onDestroy()` before nulling the instance

## Checked
- All TTS references are within ActionExecutor — no other callers need updating
- Pattern follows existing `stopSpeaking()` method
- 2 files, +7 lines, atomic fix