### PR TITLE
auto: strip recipient number from SMS success response

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -523,7 +523,7 @@ object ActionExecutor {
                 SmsManager.getDefault()
             }
             smsManager.sendTextMessage(to, null, body, null, null)
-            ActionResult(true, "SMS sent to $to")
+            ActionResult(true, "SMS sent")
         } catch (e: SecurityException) {
             ActionResult(false, "SMS permission denied: ${e.message}")
         }


### PR DESCRIPTION
## What was fixed
`sendSms()` returned `ActionResult(true, "SMS sent to $to")` — the recipient phone number flows back over the WebSocket relay. If relay traffic is logged anywhere, this leaks PII.

## Change
Response changed to `ActionResult(true, "SMS sent")`.

## What was checked
- Sibling check: `makeCall()` (line 542) has similar PII in response — separate finding, not in scope for this PR.
- No behavior change: SMS still sends, only the response message is sanitized.
- No tests: CI runs `assembleDebug` only, no test steps.

## Risk
Very low — cosmetic response change only.