### PR TITLE
docs: document AccessibilityNodeInfo recycle contract in findNodeByIdInTree

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -681,7 +681,14 @@ object ActionExecutor {
         return found
     }
 
-    /** DFS search matching the stable ID format from ScreenReader.buildNode */
+    /**
+     * DFS search matching the stable ID format from ScreenReader.buildNode.
+     *
+     * Memory contract: the returned node(s) are intentionally NOT recycled — the caller
+     * owns them and must recycle when done. Unmatched child nodes traversed during the
+     * DFS are recycled in the else-branch. Siblings after the first match are skipped
+     * (early break) and left for the system to reclaim.
+     */
     private fun findNodeByIdInTree(
         info: AccessibilityNodeInfo, targetId: String, path: String
     ): List<AccessibilityNodeInfo> {


### PR DESCRIPTION
## What was fixed
Documented the intentional non-recycle memory contract for `findNodeByIdInTree()` in ActionExecutor.kt.

## What was checked
- The audit flagged that matched nodes are returned without recycling while unmatched nodes ARE recycled. The audit itself concluded this is correct behavior — the caller owns the returned node and must recycle it.
- No code behavior changed — comment-only PR.
- Sibling-implementation check: `findNodeByIdInTree` is only called from `findNodeById` in the same file. The caller correctly recycles results after use.

## Audit reference
Issue: `Potential AccessibilityNodeInfo leak in findNodeByIdInTree` (low severity, auto_fixable: true)