### PR TITLE
auto: recycle AccessibilityWindowInfo objects in /current_app

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -138,10 +138,12 @@ object CommandDispatcher {
             method == "GET" && path == "/current_app" -> {
                 val result = withContext(Dispatchers.Main) {
                     val service = BridgeAccessibilityService.instance
-                    val root = service?.windows?.firstOrNull()?.root
+                    val windows = service?.windows ?: emptyList()
+                    val root = windows.firstOrNull()?.root
                     val pkg = root?.packageName?.toString() ?: "unknown"
                     val cls = root?.className?.toString() ?: "unknown"
                     root?.recycle()
+                    windows.forEach { it.recycle() }
                     mapOf("package" to pkg, "className" to cls)
                 }
                 result to 200


### PR DESCRIPTION
## What was fixed
The `/current_app` endpoint in CommandDispatcher.kt accessed `service.windows` but only recycled the root `AccessibilityNodeInfo`. The `AccessibilityWindowInfo` objects from the windows list were never recycled, causing gradual resource leaks on long-running bridge sessions.

## What was changed
- Stored `service.windows` in a local variable instead of chaining
- Added `windows.forEach { it.recycle() }` after extracting needed info
- Minimal 3-line diff in a single file

## What was checked
- `assembleDebug` passes
- `compileDebugUnitTestKotlin` passes
- Sibling check: `ScreenReader.kt` has the same pattern (tracked separately)
- No CI config exists, so no test files added
- Same deprecation warning as all existing `recycle()` calls in the codebase (API 35)