### PR TITLE
auto: recycle AccessibilityWindowInfo in ActionExecutor findNodeById + readWidgets

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -667,7 +667,8 @@ object ActionExecutor {
 
     private fun findNodeById(nodeId: String): AccessibilityNodeInfo? {
         val service = BridgeAccessibilityService.instance ?: return null
-        val roots = service.windows.mapNotNull { it.root }
+        val windows = service.windows
+        val roots = windows.mapNotNull { it.root }
         var found: AccessibilityNodeInfo? = null
         for ((wi, root) in roots.withIndex()) {
             val matches = findNodeByIdInTree(root, nodeId, "$wi")
@@ -678,6 +679,7 @@ object ActionExecutor {
             }
             root.recycle()
         }
+        windows.forEach { it.recycle() }
         return found
     }
 
@@ -721,12 +723,14 @@ object ActionExecutor {
         service.startActivity(homeIntent)
         delay(1000)
 
-        val roots = service.windows.mapNotNull { it.root }
+        val windows = service.windows
+        val roots = windows.mapNotNull { it.root }
         val widgets = mutableListOf<Map<String, Any?>>()
         for (root in roots) {
             collectWidgetInfo(root, widgets, 0)
             root.recycle()
         }
+        windows.forEach { it.recycle() }
 
         return ActionResult(true, "Found ${widgets.size} widget elements", mapOf("widgets" to widgets, "count" to widgets.size))
     }


### PR DESCRIPTION
## What was fixed
Two AccessibilityWindowInfo leaks in `ActionExecutor.kt`:
- `findNodeById()` (line 670): `service.windows` called, roots extracted, but window wrappers never recycled
- `readWidgets()` (line 724): same pattern

Over time these leak system memory on the Android device.

## What was checked
- **Sibling-implementation check**: Grepped all `service.windows` calls across the repo. ScreenReader.kt has the same issue (separate PR coming). CommandDispatcher.kt already has an open fix (PR #30).
- **Build gate**: `assembleDebug` passes — only pre-existing deprecation warnings.
- **Memory contract**: Roots continue to be recycled as before. Only the window wrapper recycling is added.
- **No behavioral changes**: Same logic, just adds cleanup of the window references.

## Files changed
- `hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt` (+6 lines, -2 lines)