### PR TITLE
auto: recycle AccessibilityWindowInfo in ScreenReader (3 call sites)

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ScreenReader.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ScreenReader.kt
@@ -11,9 +11,11 @@ object ScreenReader {
         val service = BridgeAccessibilityService.instance
             ?: return listOf()
 
-        val roots = service.windows.mapNotNull { it.root }
+        val windows = service.windows
+        val roots = windows.mapNotNull { it.root }
         val result = roots.mapIndexed { i, root -> buildNode(root, includeBounds, "$i") }
         roots.forEach { it.recycle() }
+        windows.forEach { it.recycle() }
         return result
     }
 
@@ -55,7 +57,8 @@ object ScreenReader {
         exact: Boolean = false
     ): AccessibilityNodeInfo? {
         val service = BridgeAccessibilityService.instance ?: return null
-        val roots = service.windows.mapNotNull { it.root }
+        val windows = service.windows
+        val roots = windows.mapNotNull { it.root }
         var found: AccessibilityNodeInfo? = null
         var foundIndex = -1
         for ((i, root) in roots.withIndex()) {
@@ -73,6 +76,7 @@ object ScreenReader {
         for (i in (foundIndex + 1) until roots.size) {
             roots[i].recycle()
         }
+        windows.forEach { it.recycle() }
         return found
     }
 
@@ -97,12 +101,14 @@ object ScreenReader {
     fun searchNodes(textFilter: String? = null, classNameFilter: String? = null, clickableFilter: Boolean? = null, limit: Int = 20): List<Map<String, Any?>> {
         val service = BridgeAccessibilityService.instance ?: return emptyList()
         val results = mutableListOf<Map<String, Any?>>()
-        val roots = service.windows.mapNotNull { it.root }
+        val windows = service.windows
+        val roots = windows.mapNotNull { it.root }
         for ((wi, root) in roots.withIndex()) {
             searchNodesDfs(root, textFilter, classNameFilter, clickableFilter, limit, results, "$wi")
             root.recycle()
             if (results.size >= limit) break
         }
+        windows.forEach { it.recycle() }
         return results
     }
 


### PR DESCRIPTION
## What was fixed
Three AccessibilityWindowInfo leaks in `ScreenReader.kt`:
- `readCurrentScreen()` (line 14): the hottest path — called on every `/screen`, `/screen_hash`, `/diff_screen`, `/find_nodes` request
- `findNodeByText()` (line 58)
- `searchNodes()` (line 100)

All called `service.windows.mapNotNull { it.root }` which extracted roots but discarded window references without recycling them. On high-traffic endpoints this leaks system memory on the device continuously.

## What was checked
- **Sibling check**: Grepped all `service.windows` across the repo. ActionExecutor.kt fixed in PR #31. CommandDispatcher.kt has PR #30 open.
- **Build gate**: `assembleDebug` passes cleanly.
- **Memory contract**: Root recycling unchanged. Only window wrapper recycling added.
- **No behavioral changes**: Same logic, just adds cleanup.

## Files changed
- `hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ScreenReader.kt` (+9 lines, -3 lines)