### PR TITLE
auto: downgrade relay body logging from INFO to DEBUG

### DIFF
--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -509,7 +509,7 @@ async def _handle_http(
         "params": params,
         "body": body,
     }
-    logger.info(">>> %s %s body=%s", method, path, json.dumps(body) if body else "{}")
+    logger.debug(">>> %s %s body=%s", method, path, json.dumps(body)[:200] if body else "{}")
 
     # Register a future *before* sending so we never miss the reply
     future = state.loop.create_future()


### PR DESCRIPTION
## What was fixed
`android_relay.py:512` logged the full request body at INFO level. This included SMS message bodies, text typed into fields, contact search queries, and any other data sent through the relay.

## Fix
- Changed `logger.info` to `logger.debug`
- Truncated body dump to 200 chars to avoid accidental large dumps even at DEBUG level

## What was checked
- Searched all `logger.info` calls in android_relay.py — other INFO logs are benign (port, connection status)
- Syntax check passes
- Single-line change, no behavioral impact on the relay itself

## Files changed
- `hermes-android-plugin/android_relay.py` (+1, -1)