### PR TITLE
auto: strip PII from makeCall and clipboardWrite responses

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -329,7 +329,7 @@ object ActionExecutor {
         val cm = service.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clip = ClipData.newPlainText("hermes", text)
         cm.setPrimaryClip(clip)
-        return ActionResult(true, "Copied to clipboard", text)
+        return ActionResult(true, "Copied to clipboard")
     }
 
     suspend fun longPress(x: Int? = null, y: Int? = null, nodeId: String? = null, duration: Long = 500): ActionResult =
@@ -539,7 +539,7 @@ object ActionExecutor {
         }
         return try {
             service.startActivity(intent)
-            ActionResult(true, if (hasCallPermission) "Calling $number" else "Opened dialer for $number (grant CALL_PHONE permission to auto-dial)")
+            ActionResult(true, if (hasCallPermission) "Calling" else "Opened dialer (grant CALL_PHONE permission to auto-dial)")
         } catch (e: SecurityException) {
             ActionResult(false, "Call failed: ${e.message}")
         }


### PR DESCRIPTION
## What was fixed

Two PII leaks in ActionExecutor response messages:

1. **makeCall** (line 542): Response messages included the phone number ("Calling $number", "Opened dialer for $number"). Stripped to just "Calling" and "Opened dialer" — matching the pattern already applied to sendSms in commit c714ab8.

2. **clipboardWrite** (line 332): Response included the clipboard text as ActionResult data. Clipboard content can include passwords, 2FA codes, and other sensitive data — removed the text from the response entirely.

## What was checked
- [x] Sibling implementation check: both methods only exist in ActionExecutor, called from CommandDispatcher
- [x] sendSms parity: already strips recipient — this fix aligns makeCall with the same pattern
- [x] Build gate: assembleDebug ✅, compileDebugUnitTestKotlin ✅
- [x] No debug prints, no TODOs, no commented-out code