### PR TITLE
auto: wrap ScreenRecorder.record() in Dispatchers.IO

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -345,7 +345,9 @@ object CommandDispatcher {
 
             method == "POST" && path == "/screen_record" -> {
                 val durationMs = body.get("durationMs")?.asLong ?: 5000L
-                val result = ScreenRecorder.record(durationMs)
+                val result = withContext(Dispatchers.IO) {
+                    ScreenRecorder.record(durationMs)
+                }
                 result to 200
             }
 


### PR DESCRIPTION
## What was fixed

ScreenRecorder.record() uses CountDownLatch.await() which blocks the calling thread for up to `durationMs + 10s`. When called from CommandDispatcher.dispatch (a coroutine), this blocked the underlying coroutine thread, potentially starving the pool if multiple recording requests overlapped.

## Fix

Wrapped the call with `withContext(Dispatchers.IO)` to isolate the blocking latch.await() on an IO dispatcher thread.

## Checked
- Only one caller of `ScreenRecorder.record()` (CommandDispatcher) — grep confirmed
- `Dispatchers.IO` import already existed in the file
- ScreenRecorder internal handler.post() still runs on its dedicated HandlerThread (the Dispatchers.IO only wraps the blocking latch.await)
- assembleDebug passes locally with no new warnings
- No debug prints, no commented-out code, no TODOs