### PR TITLE
auto: cap ScreenRecorder duration to 30s to prevent OOM

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
@@ -16,6 +16,7 @@ import java.io.File
 object ScreenRecorder {
     private const val NO_PERMISSION_MESSAGE =
         "No MediaProjection. Grant Screen Recording in the app before each capture on Android 16."
+    private const val MAX_DURATION_MS = 30_000L
 
     private var projectionResultCode: Int? = null
     private var projectionData: Intent? = null
@@ -43,6 +44,7 @@ object ScreenRecorder {
      * that created the VirtualDisplay callback handler — NOT on Dispatchers.IO.
      */
     fun record(durationMs: Long = 5000): Map<String, Any?> {
+        val safeDuration = durationMs.coerceAtMost(MAX_DURATION_MS)
         val service = BridgeAccessibilityService.instance
             ?: return mapOf("success" to false, "message" to "Accessibility service not running")
         val resultCode = projectionResultCode
@@ -97,7 +99,7 @@ object ScreenRecorder {
                 mr.start()
 
                 // Safe to block here — we're on the dedicated HandlerThread
-                Thread.sleep(durationMs)
+                Thread.sleep(safeDuration)
 
                 mr.stop()
                 mr.release()
@@ -111,12 +113,12 @@ object ScreenRecorder {
 
                 resultHolder[0] = mapOf(
                     "success" to true,
-                    "message" to "Recorded ${durationMs}ms",
+                    "message" to "Recorded ${safeDuration}ms",
                     "data" to mapOf(
                         "video" to base64Video,
                         "width" to width,
                         "height" to height,
-                        "durationMs" to durationMs,
+                        "durationMs" to safeDuration,
                         "sizeBytes" to bytes.size,
                         "mimeType" to "video/mp4"
                     )
@@ -139,7 +141,7 @@ object ScreenRecorder {
         }
 
         // Wait for the handler thread to finish (with generous timeout)
-        latch.await(durationMs + 10000, java.util.concurrent.TimeUnit.MILLISECONDS)
+        latch.await(safeDuration + 10000, java.util.concurrent.TimeUnit.MILLISECONDS)
         return resultHolder[0] ?: mapOf("success" to false, "message" to "Recording timed out")
     }
 

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -344,7 +344,7 @@ object CommandDispatcher {
             }
 
             method == "POST" && path == "/screen_record" -> {
-                val durationMs = body.get("durationMs")?.asLong ?: 5000L
+                val durationMs = body.get("durationMs")?.asLong?.coerceAtMost(30_000L) ?: 5000L
                 val result = withContext(Dispatchers.IO) {
                     ScreenRecorder.record(durationMs)
                 }


### PR DESCRIPTION
## What was fixed
ScreenRecorder.record() accepted any durationMs without bounds. Large durations produce huge MP4 files that get base64-encoded in memory, risking OOM on devices with limited heap (~15MB raw / ~20MB base64 for 60s at 2Mbps).

## Fix
Defense-in-depth cap at both layers:
- **CommandDispatcher.kt**: Clamps durationMs to 30_000L at the API entry point
- **ScreenRecorder.kt**: Adds MAX_DURATION_MS=30_000L constant and clamps internally

At 2Mbps encoding, 30s ≈ 7.5MB raw ≈ 10MB base64 — well within typical device memory limits.

## What was checked
- Only caller of ScreenRecorder.record() is CommandDispatcher (grep confirmed)
- Build: assembleDebug passes cleanly
- No debug prints, no TODOs, no new imports
- All duration usages updated (Thread.sleep, response message, latch timeout, response data)