### PR TITLE
auto: bind relay to localhost by default (ANDROID_RELAY_HOST)

### DIFF
--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -248,18 +248,20 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
     await runner.setup()
 
     ssl_ctx = _ssl_context()
-    site = web.TCPSite(runner, "0.0.0.0", state.port, ssl_context=ssl_ctx)
+    host = os.getenv("ANDROID_RELAY_HOST", "localhost")
+    site = web.TCPSite(runner, host, state.port, ssl_context=ssl_ctx)
     state.site = site
     await site.start()
 
     scheme = "https" if ssl_ctx else "http"
-    logger.info("Relay listening on %s://0.0.0.0:%d", scheme, state.port)
+    logger.info("Relay listening on %s://%s:%d", scheme, host, state.port)
 
-    if not ssl_ctx:
+    if not ssl_ctx and host != "localhost":
         logger.warning(
             "⚠️  TLS is NOT configured — all traffic (including pairing tokens) is "
             "sent in cleartext. Set ANDROID_RELAY_CERT and ANDROID_RELAY_KEY env vars "
-            "to enable TLS. Binding to 0.0.0.0 without TLS is insecure for internet-facing use."
+            "to enable TLS. Binding to %s without TLS is insecure for internet-facing use.",
+            host,
         )
 
     ready.set()

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -252,18 +252,20 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
     await runner.setup()
 
     ssl_ctx = _ssl_context()
-    site = web.TCPSite(runner, "0.0.0.0", state.port, ssl_context=ssl_ctx)
+    host = os.getenv("ANDROID_RELAY_HOST", "localhost")
+    site = web.TCPSite(runner, host, state.port, ssl_context=ssl_ctx)
     state.site = site
     await site.start()
 
     scheme = "https" if ssl_ctx else "http"
-    logger.info("Relay listening on %s://0.0.0.0:%d", scheme, state.port)
+    logger.info("Relay listening on %s://%s:%d", scheme, host, state.port)
 
-    if not ssl_ctx:
+    if not ssl_ctx and host != "localhost":
         logger.warning(
             "⚠️  TLS is NOT configured — all traffic (including pairing tokens) is "
             "sent in cleartext. Set ANDROID_RELAY_CERT and ANDROID_RELAY_KEY env vars "
-            "to enable TLS. Binding to 0.0.0.0 without TLS is insecure for internet-facing use."
+            "to enable TLS. Binding to %s without TLS is insecure for internet-facing use.",
+            host,
         )
     ready.set()
 


### PR DESCRIPTION
## What was fixed

The relay server in `android_relay.py` hardcoded `0.0.0.0` as the bind address,
exposing the pairing code and all commands to the local network without TLS by default.

## Changes
- Added `ANDROID_RELAY_HOST` env var (default: `localhost`) to control bind address
- Applied to both `tools/android_relay.py` and `hermes-android-plugin/android_relay.py`
- TLS warning now only fires when bound to a non-localhost address without TLS
- To restore previous behavior: set `ANDROID_RELAY_HOST=0.0.0.0`

## Verified
- Both files parse cleanly (AST check)
- All stdlib and aiohttp imports verified
- Sibling implementation in BridgeServer.kt (on-device server) intentionally left at 0.0.0.0 — that's the phone-side bridge