### PR TITLE
auto: fix ConcurrentLinkedDeque race condition in EventStore and NotificationStore

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
@@ -15,35 +15,28 @@ data class AccessibilityEventData(
 
 object EventStore {
     private val events = ConcurrentLinkedDeque<AccessibilityEventData>()
+    private val lock = Any()
     var maxCapacity: Int = 200
     var streamingEnabled: Boolean = false
 
     fun add(event: AccessibilityEvent) {
-        if (events.size >= maxCapacity) {
-            events.removeLast()
-        }
-
-        val eventTypeStr = when (event.eventType) {
-            AccessibilityEvent.TYPE_VIEW_CLICKED -> "VIEW_CLICKED"
-            AccessibilityEvent.TYPE_VIEW_FOCUSED -> "VIEW_FOCUSED"
-            AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED -> "VIEW_TEXT_CHANGED"
-            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> "WINDOW_STATE_CHANGED"
-            AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> "WINDOW_CONTENT_CHANGED"
-            AccessibilityEvent.TYPE_VIEW_SCROLLED -> "VIEW_SCROLLED"
-            AccessibilityEvent.TYPE_VIEW_SELECTED -> "VIEW_SELECTED"
-            AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED -> "VIEW_TEXT_SELECTION_CHANGED"
-            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED -> "NOTIFICATION_STATE_CHANGED"
-            AccessibilityEvent.TYPE_VIEW_LONG_CLICKED -> "VIEW_LONG_CLICKED"
-            else -> "OTHER_${event.eventType}"
-        }
-
-        val text = event.text?.joinToString(", ") ?: ""
-
-        events.addFirst(AccessibilityEventData(
-            eventType = eventTypeStr,
+        val entry = AccessibilityEventData(
+            eventType = when (event.eventType) {
+                AccessibilityEvent.TYPE_VIEW_CLICKED -> "VIEW_CLICKED"
+                AccessibilityEvent.TYPE_VIEW_FOCUSED -> "VIEW_FOCUSED"
+                AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED -> "VIEW_TEXT_CHANGED"
+                AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> "WINDOW_STATE_CHANGED"
+                AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> "WINDOW_CONTENT_CHANGED"
+                AccessibilityEvent.TYPE_VIEW_SCROLLED -> "VIEW_SCROLLED"
+                AccessibilityEvent.TYPE_VIEW_SELECTED -> "VIEW_SELECTED"
+                AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED -> "VIEW_TEXT_SELECTION_CHANGED"
+                AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED -> "NOTIFICATION_STATE_CHANGED"
+                AccessibilityEvent.TYPE_VIEW_LONG_CLICKED -> "VIEW_LONG_CLICKED"
+                else -> "OTHER_${event.eventType}"
+            },
             packageName = event.packageName?.toString(),
             className = event.className?.toString(),
-            text = text.ifBlank { null },
+            text = event.text?.joinToString(", ")?.ifBlank { null },
             contentDescription = event.contentDescription?.toString(),
             sourceNodeId = event.source?.let { src ->
                 try {
@@ -53,7 +46,14 @@ object EventStore {
                 } finally { src.recycle() }
             },
             timestamp = event.eventTime
-        ))
+        )
+
+        synchronized(lock) {
+            if (events.size >= maxCapacity) {
+                events.removeLast()
+            }
+            events.addFirst(entry)
+        }
     }
 
     fun getAll(limit: Int = 50): List<AccessibilityEventData> {

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
@@ -23,13 +23,16 @@ data class NotificationEntry(
 object NotificationStore {
 
     private val notifications = ConcurrentLinkedDeque<NotificationEntry>()
+    private val lock = Any()
     var maxCapacity: Int = 50
 
     fun add(entry: NotificationEntry) {
-        if (notifications.size >= maxCapacity) {
-            notifications.removeLast()
+        synchronized(lock) {
+            if (notifications.size >= maxCapacity) {
+                notifications.removeLast()
+            }
+            notifications.addFirst(entry)
         }
-        notifications.addFirst(entry)
     }
 
     fun getAll(limit: Int = 50): List<NotificationEntry> {


### PR DESCRIPTION
## What was fixed

EventStore.add() and NotificationStore.add() had a non-atomic
size-check-then-removeLast pattern on ConcurrentLinkedDeque. Between
the size check and removeLast(), another thread could modify the deque,
causing capacity overshoot or NoSuchElementException.

## Changes
- Added `private val lock = Any()` to both EventStore and NotificationStore
- Wrapped the size-check + removeLast + addFirst in `synchronized(lock)` 
- Read-only methods (getAll, getSince, clear) remain unsynchronized since
  ConcurrentLinkedDeque handles concurrent reads safely

## Verified
- `./gradlew assembleDebug` passes (BUILD SUCCESSFUL)
- Only two files in the repo use ConcurrentLinkedDeque — both fixed