### PR TITLE
auto: remove dead code in ActionExecutor.diffScreen

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -404,21 +404,24 @@ object ActionExecutor {
         if (currentHash == previousHash) {
             return ActionResult(true, "No changes detected", mapOf("changed" to false, "hash" to currentHash))
         }
-        val currentNodeIds = mutableSetOf<String>()
-        val currentTexts = mutableMapOf<String, String?>()
-        fun collectCurrent(ns: List<com.hermesandroid.bridge.model.ScreenNode>) {
-            for (n in ns) {
-                currentNodeIds.add(n.nodeId)
-                currentTexts[n.nodeId] = n.text
-                collectCurrent(n.children)
-            }
-        }
-        collectCurrent(nodes)
+        val nodeCount = countNodes(nodes)
         return ActionResult(true, "Screen changed", mapOf(
             "changed" to true,
             "hash" to currentHash,
-            "nodeCount" to currentNodeIds.size
+            "nodeCount" to nodeCount
         ))
+    }
+
+    private fun countNodes(nodes: List<com.hermesandroid.bridge.model.ScreenNode>): Int {
+        var count = 0
+        fun walk(ns: List<com.hermesandroid.bridge.model.ScreenNode>) {
+            for (n in ns) {
+                count++
+                walk(n.children)
+            }
+        }
+        walk(nodes)
+        return count
     }
 
     suspend fun pinch(x: Int, y: Int, scale: Float = 1.5f, duration: Long = 300): ActionResult =


### PR DESCRIPTION
## What was fixed

`diffScreen()` collected node IDs and texts into local variables (`currentNodeIds`, `currentTexts`) but only used `currentNodeIds.size` in the response. `currentTexts` was entirely dead — populated but never read.

## Changes
- Removed unused `currentTexts` map and `currentNodeIds` set
- Replaced with a simple `countNodes()` private helper
- Avoids unnecessary Set and Map allocations per call
- API contract unchanged (`changed`, `hash`, `nodeCount`)

## Verified
- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- Grep for diffScreen/diff_screen callers — all consume the response shape identically