### PR TITLE
auto: synchronize EventStore clear/getAll/getSince with lock

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
@@ -57,15 +57,21 @@ object EventStore {
     }
 
     fun getAll(limit: Int = 50): List<AccessibilityEventData> {
-        return events.take(limit)
+        synchronized(lock) {
+            return events.take(limit)
+        }
     }
 
     fun getSince(sinceTimestamp: Long, limit: Int = 50): List<AccessibilityEventData> {
-        return events.filter { it.timestamp > sinceTimestamp }.take(limit)
+        synchronized(lock) {
+            return events.filter { it.timestamp > sinceTimestamp }.take(limit)
+        }
     }
 
     fun clear() {
-        events.clear()
+        synchronized(lock) {
+            events.clear()
+        }
     }
 
     fun setStreaming(enabled: Boolean) {


### PR DESCRIPTION
## What was fixed
EventStore.add() acquires `lock` for the size-check/removeLast/addFirst critical section, but clear(), getAll(), and getSince() do NOT acquire the lock.

This causes a race condition: if setStreaming(false) -> clear() runs concurrently with add(), entries can be added after clear(), violating the 'streaming disabled = no events' invariant. getAll() could also return an inconsistent snapshot during a concurrent add().

## What was changed
- Wrapped clear(), getAll(), and getSince() bodies in `synchronized(lock)`
- Parity with add() which already acquires the lock
- No behavior change for single-threaded usage

## What was checked
- Sibling implementations: all callers are in CommandDispatcher.kt — fix is self-contained in EventStore
- Build: assembleDebug passes
- No new warnings from this change