### PR TITLE
auto: synchronize NotificationStore.markRemoved() with lock

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
@@ -48,7 +48,9 @@ object NotificationStore {
     }
 
     fun markRemoved(key: String) {
-        notifications.find { it.key == key }?.removed = true
+        synchronized(lock) {
+            notifications.find { it.key == key }?.removed = true
+        }
     }
 
     fun parseNotification(sbn: StatusBarNotification): NotificationEntry? {


### PR DESCRIPTION
## What was fixed
NotificationStore.markRemoved() iterates the ConcurrentLinkedDeque and mutates entries without acquiring the lock, while add() does acquire it. This is inconsistent with the synchronized pattern used in add() and could lead to stale reads of the removed flag.

## What was changed
- Wrapped markRemoved() body in `synchronized(lock)` for consistency with add()
- No behavior change for single-threaded usage

## What was checked
- Sibling implementations: single caller in BridgeNotificationListener.kt — fix is self-contained
- Build: assembleDebug passes
- No new warnings from this change