### PR TITLE
auto: exact-case pairing code comparison to preserve auth entropy

### DIFF
--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -368,7 +368,9 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     token = request.query.get("token", "")
     # Constant-time comparison to mitigate timing side-channel attacks that
     # could otherwise leak the pairing code byte-by-byte.
-    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
+    # PairingManager generates uppercase-only codes — compare exact-case to
+    # preserve full key-space entropy.
+    if not hmac.compare_digest(token, state.pairing_code):
         _auth_record_failure(remote_ip)
         logger.warning(
             "Phone WS rejected — bad token (got %s) from %s", _mask_token(token), remote_ip
@@ -473,7 +475,7 @@ async def _handle_http(
 
     auth_header = request.headers.get("Authorization", "")
     token = auth_header.removeprefix("Bearer ").strip() if auth_header.startswith("Bearer ") else ""
-    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
+    if not hmac.compare_digest(token, state.pairing_code):
         _auth_record_failure(remote_ip)
         logger.warning(
             "HTTP %s %s rejected — bad auth from %s (header=%s)",

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -371,7 +371,9 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     token = request.query.get("token", "")
     # Constant-time comparison to mitigate timing side-channel attacks that
     # could otherwise leak the pairing code byte-by-byte.
-    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
+    # PairingManager generates uppercase-only codes — compare exact-case to
+    # preserve full key-space entropy.
+    if not hmac.compare_digest(token, state.pairing_code):
         _auth_record_failure(remote_ip)
         logger.warning(
             "Phone WS rejected — bad token (got %s) from %s", _mask_token(token), remote_ip
@@ -476,7 +478,7 @@ async def _handle_http(
 
     auth_header = request.headers.get("Authorization", "")
     token = auth_header.removeprefix("Bearer ").strip() if auth_header.startswith("Bearer ") else ""
-    if not hmac.compare_digest(token.upper(), state.pairing_code.upper()):
+    if not hmac.compare_digest(token, state.pairing_code):
         _auth_record_failure(remote_ip)
         logger.warning(
             "HTTP %s %s rejected — bad auth from %s (header=%s)",


### PR DESCRIPTION
## What was fixed
The pairing code auth used `.upper()` on both sides of `hmac.compare_digest()`, making the 6-char alphanumeric code effectively case-insensitive. This halves the key-space per character (from 62 to 36 possible values per position).

`PairingManager` already generates uppercase-only codes, so `.upper()` on the expected side was a no-op — but on the supplied token side it allowed lowercase variants to pass.

## What was changed
- Removed `.upper()` from both sides of `hmac.compare_digest()` in 4 locations:
  - `tools/android_relay.py` — WS auth (line 374) and HTTP auth (line 479)
  - `hermes-android-plugin/android_relay.py` — WS auth (line 371) and HTTP auth (line 476)
- Added comment explaining why exact-case comparison is used

## What was checked
- Sibling implementation parity: both `tools/` and `hermes-android-plugin/` copies fixed
- Python syntax check passed for both files
- No debug prints, no commented-out code, no TODOs