### PR TITLE
auto: align pressKey schema with actually supported keys

### DIFF
--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -203,8 +203,8 @@ def android_open_app(package: str) -> str:
 def android_press_key(key: str) -> str:
     """
     Press a key. Supported keys:
-      back, home, recents, power, volume_up, volume_down,
-      enter, delete, tab, escape, search, notifications
+      back, home, recents, power, notifications,
+      quick_settings, lock_screen, take_screenshot
     """
     try:
         data = _post("/press_key", {"key": key})
@@ -944,14 +944,10 @@ _SCHEMAS = {
                         "home",
                         "recents",
                         "power",
-                        "volume_up",
-                        "volume_down",
-                        "enter",
-                        "delete",
-                        "tab",
-                        "escape",
-                        "search",
                         "notifications",
+                        "quick_settings",
+                        "lock_screen",
+                        "take_screenshot",
                     ],
                 }
             },

--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -227,8 +227,8 @@ def android_open_app(package: str) -> str:
 def android_press_key(key: str) -> str:
     """
     Press a key. Supported keys:
-      back, home, recents, power, volume_up, volume_down,
-      enter, delete, tab, escape, search, notifications
+      back, home, recents, power, notifications,
+      quick_settings, lock_screen, take_screenshot
     """
     try:
         data = _post("/press_key", {"key": key})
@@ -971,14 +971,10 @@ _SCHEMAS = {
                         "home",
                         "recents",
                         "power",
-                        "volume_up",
-                        "volume_down",
-                        "enter",
-                        "delete",
-                        "tab",
-                        "escape",
-                        "search",
                         "notifications",
+                        "quick_settings",
+                        "lock_screen",
+                        "take_screenshot",
                     ],
                 }
             },


### PR DESCRIPTION
## What was fixed
The pressKey tool schema advertised 7 unsupported keys (volume_up, volume_down, enter, delete, tab, escape, search). ActionExecutor.pressKey() returns an error for all of these — "Key X is not supported via AccessibilityService global actions". The LLM would try these keys and always get errors.

Additionally, 3 actually-supported keys were missing from the schema: quick_settings, lock_screen, take_screenshot.

## What was changed
- Removed 7 unsupported keys from the enum and docstring
- Added 3 implemented-but-undocumented keys: quick_settings, lock_screen, take_screenshot
- Applied to both `tools/android_tool.py` and `hermes-android-plugin/android_tool.py`

## What was checked
- Verified ActionExecutor.pressKey() `when` block in ActionExecutor.kt — only back, home, recents, power, notifications, quick_settings, lock_screen, take_screenshot have actual implementations
- Sibling implementation parity: both copies fixed
- Python syntax check passed