### PR TITLE
auto: synchronize NotificationStore getAll/getSince/clear

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
@@ -36,15 +36,21 @@ object NotificationStore {
     }
 
     fun getAll(limit: Int = 50): List<NotificationEntry> {
-        return notifications.filter { !it.removed }.take(limit)
+        synchronized(lock) {
+            return notifications.filter { !it.removed }.take(limit)
+        }
     }
 
     fun getSince(sinceTimestamp: Long, limit: Int = 50): List<NotificationEntry> {
-        return notifications.filter { !it.removed && it.timestamp > sinceTimestamp }.take(limit)
+        synchronized(lock) {
+            return notifications.filter { !it.removed && it.timestamp > sinceTimestamp }.take(limit)
+        }
     }
 
     fun clear() {
-        notifications.clear()
+        synchronized(lock) {
+            notifications.clear()
+        }
     }
 
     fun markRemoved(key: String) {


### PR DESCRIPTION
## What was fixed

`NotificationStore.getAll()`, `getSince()`, and `clear()` lacked synchronization while `add()` and `markRemoved()` were already synchronized on `lock`. This caused reads during concurrent modifications to see partially-modified state.

## What was changed

- Wrapped `getAll()`, `getSince()`, and `clear()` in `synchronized(lock)` blocks
- Matches the pattern already used in `EventStore` (same codebase)

## What was checked

- Build: `assembleDebug` passes ✅
- Sibling check: verified `CommandDispatcher.kt` is the only consumer of `getAll`/`getSince` — no other implementations exist
- No debug prints, no TODOs, no commented-out code