### PR TITLE
auto: fix typeText clearFirst clobbering clipboard

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -106,16 +106,12 @@ object ActionExecutor {
 
         try {
             if (clearFirst) {
-                val bundle = Bundle()
-                bundle.putInt(
-                    AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_START_INT, 0
-                )
-                bundle.putInt(
-                    AccessibilityNodeInfo.ACTION_ARGUMENT_SELECTION_END_INT,
-                    focusedNode?.text?.length ?: 0
-                )
-                focusedNode?.performAction(AccessibilityNodeInfo.ACTION_SET_SELECTION, bundle)
-                focusedNode?.performAction(AccessibilityNodeInfo.ACTION_CUT)
+                val clearArgs = Bundle().apply {
+                    putCharSequence(
+                        AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, ""
+                    )
+                }
+                focusedNode?.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, clearArgs)
             }
 
             val arguments = Bundle().apply {


### PR DESCRIPTION
## What was fixed

`typeText(clearFirst=true)` used `ACTION_SET_SELECTION` + `ACTION_CUT` to clear existing text. `ACTION_CUT` copies the selected text to the clipboard, silently overwriting whatever the user had stored there.

## What was changed

Replaced with `ACTION_SET_TEXT` + empty string, which clears the text field without touching the clipboard. Simpler and correct.

Note: The audit suggested `ACTION_DELETE` but that constant doesn't exist in Android's `AccessibilityNodeInfo`. Using `ACTION_SET_TEXT` with an empty string is the standard approach.

## What was checked

- Build: `assembleDebug` passes ✅
- Sibling check: no other implementations of typeText clearFirst exist
- No debug prints, no TODOs