### PR TITLE
auto: downgrade relay body logging from INFO to DEBUG in tools/

### DIFF
--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -516,7 +516,7 @@ async def _handle_http(
         "params": params,
         "body": body,
     }
-    logger.info(">>> %s %s body=%s", method, path, json.dumps(body) if body else "{}")
+    logger.debug(">>> %s %s body=%s", method, path, json.dumps(body)[:200] if body else "{}")
 
     # Register a future *before* sending so we never miss the reply
     future = state.loop.create_future()


### PR DESCRIPTION
## What was fixed

`tools/android_relay.py` logged full request bodies at INFO level, including sensitive data like SMS text, clipboard content, and typed text. The plugin version (`hermes-android-plugin/android_relay.py`) was already fixed to use DEBUG + 200-char truncation, but the tools/ copy was missed.

## What was changed

- Changed `logger.info` → `logger.debug` on line 519
- Added 200-char truncation to body dump, matching the plugin version

## What was checked

- Syntax check passes ✅
- Matches the identical fix already applied to `hermes-android-plugin/android_relay.py`
- Sibling check: verified the plugin version is the only other copy