### PR TITLE
auto: add runtime permission guard to ActionExecutor.location()

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -485,27 +485,35 @@ object ActionExecutor {
     fun location(): ActionResult {
         val service = BridgeAccessibilityService.instance
             ?: return ActionResult(false, "Accessibility service not running")
-        val lm = service.getSystemService(Context.LOCATION_SERVICE) as android.location.LocationManager
-        val providers = lm.getProviders(true)
-        var best: android.location.Location? = null
-        for (provider in providers) {
-            @Suppress("DEPRECATION")
-            val loc = lm.getLastKnownLocation(provider) ?: continue
-            if (best == null || loc.accuracy < best.accuracy) {
-                best = loc
+        if (!service.hasSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) &&
+            !service.hasSelfPermission(android.Manifest.permission.ACCESS_COARSE_LOCATION)) {
+            return ActionResult(false, "Location permission not granted. Grant it in Settings > Apps > Hermes Bridge > Permissions.")
+        }
+        return try {
+            val lm = service.getSystemService(Context.LOCATION_SERVICE) as android.location.LocationManager
+            val providers = lm.getProviders(true)
+            var best: android.location.Location? = null
+            for (provider in providers) {
+                @Suppress("DEPRECATION")
+                val loc = lm.getLastKnownLocation(provider) ?: continue
+                if (best == null || loc.accuracy < best.accuracy) {
+                    best = loc
+                }
             }
+            if (best == null) {
+                return ActionResult(false, "No location available. Enable GPS/Location.")
+            }
+            ActionResult(true, "Location", mapOf(
+                "latitude" to best.latitude,
+                "longitude" to best.longitude,
+                "accuracy" to best.accuracy,
+                "altitude" to best.altitude,
+                "provider" to (best.provider ?: "unknown"),
+                "timestamp" to best.time
+            ))
+        } catch (e: SecurityException) {
+            ActionResult(false, "Location permission denied: ${e.message}")
         }
-        if (best == null) {
-            return ActionResult(false, "No location available. Enable GPS/Location.")
-        }
-        return ActionResult(true, "Location", mapOf(
-            "latitude" to best.latitude,
-            "longitude" to best.longitude,
-            "accuracy" to best.accuracy,
-            "altitude" to best.altitude,
-            "provider" to (best.provider ?: "unknown"),
-            "timestamp" to best.time
-        ))
     }
 
     fun sendSms(to: String, body: String): ActionResult {


### PR DESCRIPTION
## What was fixed

`location()` called `LocationManager.getProviders(true)` and `getLastKnownLocation(provider)` without checking `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` at runtime, and was not wrapped in a try/catch. An ungranted permission surfaced as an opaque HTTP 500 instead of clear guidance.

## Root cause

Every sibling method (`sendSms`, `makeCall`, `searchContacts`) guards with `hasSelfPermission()` + `try/catch(SecurityException)`. `location()` did neither — an oversight.

## Fix

Mirrors the `sendSms()` pattern exactly:
1. Explicit permission check (`ACCESS_FINE_LOCATION` OR `ACCESS_COARSE_LOCATION`) returning a friendly "Grant it in Settings > Apps > Hermes Bridge > Permissions" message
2. `try/catch(SecurityException)` around the provider loop returning "Location permission denied"

## What was checked
- [x] Sibling parity: confirmed all 3 sibling methods use the same pattern
- [x] Single implementation: `location()` called only from `CommandDispatcher.kt:249`
- [x] Build: `./gradlew assembleDebug` passes (no new warnings)
- [x] No debug prints, no TODOs, no commented-out code
- [x] 1 file changed, 27 insertions, 19 deletions