### PR TITLE
auto: null-check Bitmap.copy() result in takeScreenshot

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -242,6 +242,10 @@ object ActionExecutor {
                         val bitmap = hwBitmap.copy(Bitmap.Config.ARGB_8888, false)
                         hwBitmap.recycle()
                         result.hardwareBuffer.close()
+                        if (bitmap == null) {
+                            cont.resume(ActionResult(false, "Failed to copy screenshot bitmap"))
+                            return
+                        }
 
                         val w = bitmap.width
                         val h = bitmap.height


### PR DESCRIPTION
## What was fixed

`Bitmap.copy(Bitmap.Config.ARGB_8888, false)` can return null under memory pressure (documented Android behavior). The result was used immediately as `bitmap.width` and `bitmap.compress(...)` with no null check, causing an NPE inside the `onSuccess` callback — which runs outside the suspendCancellableCoroutine's structured error path and can crash the process.

## Fix

Added a null guard after `hwBitmap.copy()` that mirrors the existing `hwBitmap` null-check pattern already present 6 lines above (lines 236-239). On null, it resumes the coroutine with a friendly error and returns.

The `hwBitmap.recycle()` and `result.hardwareBuffer.close()` calls are placed before the null check so native resources are always cleaned up regardless of copy success/failure.

## What was checked
- [x] Mirrors existing null-guard pattern in the same callback
- [x] Resource cleanup (recycle/close) happens before the null check
- [x] Build: `./gradlew assembleDebug` passes
- [x] No debug prints, no TODOs
- [x] 1 file changed, 4 insertions