### PR TITLE
feat(bridge): add per-IP auth rate limiting to BridgeServer

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/AuthRateLimiter.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/AuthRateLimiter.kt
@@ -1,0 +1,57 @@
+package com.hermesandroid.bridge.server
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Per-IP auth-failure throttle.
+ *
+ * Mirrors the policy enforced by the Python relay (`android_relay.py`):
+ * [maxAttempts] failures within a sliding [windowMs] window block the IP for
+ * [blockMs]. The bridge binds `0.0.0.0:8765` by default, so without this a
+ * host on a shared/hostile network can brute-force the 6-char pairing code
+ * directly, bypassing the relay's own throttle. A cracked code yields full
+ * remote control of the device.
+ *
+ * [now] is injected so the sliding-window/block behaviour is deterministic
+ * under test.
+ */
+internal class AuthRateLimiter(
+    private val maxAttempts: Int = 5,
+    private val windowMs: Long = 60_000L,
+    private val blockMs: Long = 300_000L,
+    private val now: () -> Long = { System.currentTimeMillis() },
+) {
+    private val failures = ConcurrentHashMap<String, MutableList<Long>>()
+    private val blocked = ConcurrentHashMap<String, Long>()
+
+    /**
+     * Returns `true` if [ip] is currently blocked. Clears the block once it
+     * has expired.
+     */
+    fun isBlocked(ip: String): Boolean {
+        val until = blocked[ip] ?: return false
+        if (now() < until) return true
+        blocked.remove(ip)
+        return false
+    }
+
+    /**
+     * Records a failed auth attempt for [ip]. Once [maxAttempts] failures
+     * accumulate within [windowMs], the IP is blocked for [blockMs] and its
+     * failure history is cleared.
+     */
+    fun recordFailure(ip: String) {
+        val t = now()
+        val cutoff = t - windowMs
+        val attempts = failures.computeIfAbsent(ip) { mutableListOf() }
+        synchronized(attempts) {
+            // Drop attempts that fell out of the sliding window.
+            attempts.removeAll { it <= cutoff }
+            attempts.add(t)
+            if (attempts.size >= maxAttempts) {
+                blocked[ip] = t + blockMs
+                attempts.clear()
+            }
+        }
+    }
+}

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/BridgeServer.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/BridgeServer.kt
@@ -13,6 +13,10 @@ import io.ktor.server.response.*
 object BridgeServer {
     private var server: ApplicationEngine? = null
 
+    // Per-IP auth throttle — defends the 0.0.0.0:8765 bind against
+    // brute-forcing the pairing code (see AuthRateLimiter).
+    private val authRateLimiter = AuthRateLimiter()
+
     fun start(port: Int = 8765) {
         if (server != null) return
         server = embeddedServer(Netty, port = port, host = "0.0.0.0") {
@@ -22,15 +26,25 @@ object BridgeServer {
                     serializeNulls()
                 }
             }
-            // Auth interceptor — every request must have valid Bearer token
+            // Auth interceptor — every request must have a valid Bearer token.
+            // /ping is allowed without auth so the agent can discover the
+            // bridge, but it does not return sensitive data.
             intercept(ApplicationCallPipeline.Plugins) {
                 val path = call.request.path()
-                // Allow /ping without auth so the agent can discover the bridge,
-                // but it won't return sensitive data without auth
                 if (path == "/ping") return@intercept
+
+                val ip = call.request.local.remoteHost
+                if (authRateLimiter.isBlocked(ip)) {
+                    call.respond(HttpStatusCode.TooManyRequests, mapOf(
+                        "error" to "Too many failed authentication attempts. Try again later."
+                    ))
+                    finish()
+                    return@intercept
+                }
 
                 val authHeader = call.request.header(HttpHeaders.Authorization)
                 if (!PairingManager.validateToken(authHeader)) {
+                    authRateLimiter.recordFailure(ip)
                     call.respond(HttpStatusCode.Unauthorized, mapOf(
                         "error" to "Invalid or missing pairing code",
                         "hint" to "Set ANDROID_BRIDGE_TOKEN to the code shown in the Hermes Bridge app"

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/server/AuthRateLimiterTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/server/AuthRateLimiterTest.kt
@@ -1,0 +1,61 @@
+package com.hermesandroid.bridge.server
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AuthRateLimiterTest {
+
+    @Test
+    fun `allows requests until the failure threshold is reached`() {
+        var t = 1000L
+        val rl = AuthRateLimiter(maxAttempts = 3, windowMs = 100, blockMs = 200) { t }
+
+        rl.recordFailure("1.2.3.4")
+        rl.recordFailure("1.2.3.4")
+        assertFalse("2 failures should not block", rl.isBlocked("1.2.3.4"))
+
+        rl.recordFailure("1.2.3.4") // 3rd in-window failure -> blocked
+        assertTrue("3rd failure should block", rl.isBlocked("1.2.3.4"))
+    }
+
+    @Test
+    fun `block expires after blockMs`() {
+        var t = 1000L
+        val rl = AuthRateLimiter(maxAttempts = 2, windowMs = 100, blockMs = 200) { t }
+
+        repeat(2) { rl.recordFailure("10.0.0.1") }
+        assertTrue(rl.isBlocked("10.0.0.1"))
+
+        t += 201 // past the block window
+        assertFalse("block should expire", rl.isBlocked("10.0.0.1"))
+    }
+
+    @Test
+    fun `failures outside the sliding window do not count`() {
+        var t = 1000L
+        val rl = AuthRateLimiter(maxAttempts = 3, windowMs = 100, blockMs = 200) { t }
+
+        rl.recordFailure("9.9.9.9") // at t=1000
+        t += 101 // the first failure is now outside the 100ms window
+        rl.recordFailure("9.9.9.9")
+        rl.recordFailure("9.9.9.9") // only 2 in-window failures remain
+        assertFalse("stale failures should be evicted", rl.isBlocked("9.9.9.9"))
+    }
+
+    @Test
+    fun `different IPs are tracked independently`() {
+        var t = 1000L
+        val rl = AuthRateLimiter(maxAttempts = 2, windowMs = 100, blockMs = 200) { t }
+
+        repeat(2) { rl.recordFailure("attacker") }
+        assertTrue(rl.isBlocked("attacker"))
+        assertFalse("unrelated IP must not be blocked", rl.isBlocked("bystander"))
+    }
+
+    @Test
+    fun `a clean IP is never blocked`() {
+        val rl = AuthRateLimiter { 1000L }
+        assertFalse(rl.isBlocked("never-seen"))
+    }
+}


### PR DESCRIPTION
## What

`BridgeServer` unconditionally binds the ktor Netty server to `0.0.0.0:8765` on every launch (needed for the documented direct-WiFi/USB path), but the auth interceptor only validated the pairing code with **no rate limiting**. This is asymmetric with the Python relay (`android_relay.py`), which binds localhost by default AND enforces a 5-fail / 60s -> 5min IP block.

The pairing code is 6 chars from a 32-char alphabet (~1.07e9 space). On a shared/hostile network (cafe/hotel/office) an attacker can hammer the phone's port directly, bypassing the relay's throttle entirely. A cracked code yields **full remote control**: tap/type, SMS, calls, clipboard, contacts, location, screenshots. The relay path is well-protected; the phone's own server was the weak link.

## Fix
Mirror the relay's defense on the phone side: track failed `validateToken()` attempts per remote IP — 5 failures within a 60s sliding window block the IP for 300s, returning HTTP 429. Logic lives in a new `AuthRateLimiter` (thread-safe via `ConcurrentHashMap` + per-IP lock), so it is unit-testable.

`/ping` still bypasses auth (unchanged). The `0.0.0.0` bind is intentionally kept (needed for direct WiFi/USB); the rate limiter is the missing control.

## Verification (local, JDK 17)
- `./gradlew compileDebugUnitTestKotlin` — OK
- `./gradlew testDebugUnitTest` — OK (5 new `AuthRateLimiterTest` cases: threshold, block expiry, sliding-window eviction, per-IP isolation, clean-IP)
- `./gradlew assembleDebug` — OK

## Files
- `AuthRateLimiter.kt` (new) — per-IP throttle, mirroring `android_relay.py` policy
- `BridgeServer.kt` — wire the limiter into the auth interceptor (429 on block, record on failure)
- `AuthRateLimiterTest.kt` (new) — unit tests (CI runs `testDebugUnitTest`)

## Not done (out of scope, separate concerns)
- Making the bind host configurable (localhost-only) — separate finding, defer.