### PR TITLE
fix(android_macro): halt on transport-level errors

### DIFF
--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -443,7 +443,13 @@ def android_macro(steps: list, name: str = "unnamed") -> str:
             )
             results.append({"step": i, "tool": tool_name, "result": result})
 
-            if isinstance(result, dict) and not result.get("success", True):
+            # A failure is either an explicit success=False (action ran but
+            # was rejected) or an "error"-keyed transport/exception result
+            # (no "success" key) — the latter previously defaulted to True and
+            # let the macro silently continue past a real network/JSON error.
+            if isinstance(result, dict) and (
+                result.get("success") is False or "error" in result
+            ):
                 return json.dumps(
                     {
                         "error": f"Step {i} ({tool_name}) failed",

--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -467,7 +467,13 @@ def android_macro(steps: list, name: str = "unnamed") -> str:
             )
             results.append({"step": i, "tool": tool_name, "result": result})
 
-            if isinstance(result, dict) and not result.get("success", True):
+            # A failure is either an explicit success=False (action ran but
+            # was rejected) or an "error"-keyed transport/exception result
+            # (no "success" key) — the latter previously defaulted to True and
+            # let the macro silently continue past a real network/JSON error.
+            if isinstance(result, dict) and (
+                result.get("success") is False or "error" in result
+            ):
                 return json.dumps(
                     {
                         "error": f"Step {i} ({tool_name}) failed",


### PR DESCRIPTION
## What was fixed

`android_macro` documents **"stops on first failure"**, but its failure check was:

```python
if isinstance(result, dict) and not result.get("success", True):
```

This defaults to `True` for any dict **without** a `success` key. Transport/exception errors are returned as `{"error": ...}` (no `success` key), so a network/timeout/JSON error silently read as **success** and the macro continued executing subsequent steps — tapping/typing into a stale screen.

## The fix

Treat any dict result as a failure if it has an explicit `success: false` **OR** contains an `error` key:

```python
if isinstance(result, dict) and (
    result.get("success") is False or "error" in result
):
```

Applied to **both** copies to keep them in sync:
- `tools/android_tool.py`
- `hermes-android-plugin/android_tool.py`

## What was checked
- **Sibling-implementation check:** `grep -rn 'not result.get("success", True)'` across the repo found exactly these two implementations — both fixed.
- **Build gate:** full Python test suite passes locally (`105 passed`), including the existing `TestMacro` suite.
- **Behavior verified (ad-hoc):** a step returning `{"error": "Connection refused"}` now correctly halts the macro (`completed=0`) on **both** copies — previously it continued.
- No test file added: the repo's CI (`.github/workflows/build.yml`) only triggers on `hermes-android-bridge/**` and never runs the Python `tests/` — so a committed test would be dead weight. Behavior was verified locally instead.