### PR TITLE
auto: wrap /wait handler in withContext(Dispatchers.Main)

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -126,7 +126,9 @@ object CommandDispatcher {
                 val text = body.get("text")?.asString
                 val className = body.get("className")?.asString
                 val timeoutMs = body.get("timeoutMs")?.asInt ?: 5000
-                val result = ActionExecutor.waitForElement(text, className, timeoutMs)
+                val result = withContext(Dispatchers.Main) {
+                    ActionExecutor.waitForElement(text, className, timeoutMs)
+                }
                 result to 200
             }
 


### PR DESCRIPTION
## What was fixed

The `/wait` endpoint in `CommandDispatcher` called `ActionExecutor.waitForElement()` directly with no dispatcher switch — inconsistent with its sibling endpoints `/screen` and `/screen_hash`, which both wrap their `ScreenReader` calls in `withContext(Dispatchers.Main)`.

`waitForElement()` loops calling `ScreenReader.readCurrentScreen(false)`, which touches `AccessibilityService.windows` and `getChild()` — APIs documented for main-thread use. Reading the accessibility tree off-main can yield unreliable/empty reads on some Android versions, causing waits to time out spuriously.

## What was changed
- Wrapped the `waitForElement` call in `withContext(Dispatchers.Main) { ... }`, matching the established pattern of `/screen`, `/screen_hash`, `/screenshot`, `/tap`, `/type`, etc.

## What was checked
- **Sibling parity**: verified `/screen` (line 53) and `/screen_hash` (line 242) both use `withContext(Dispatchers.Main)` — this fix brings `/wait` in line
- **waitForElement signature**: confirmed it's `suspend fun` and uses `delay()` (ActionExecutor.kt:200), so moving it onto Main is safe — it yields the dispatcher between 500ms polls
- **Single call site**: `waitForElement` has exactly one caller (this endpoint)

## Verification
- `./gradlew assembleDebug` — **BUILD SUCCESSFUL** in 29s