### PR TITLE
auto: add @Volatile to cross-thread mutable fields in EventStore and NotificationStore

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
@@ -16,8 +16,8 @@ data class AccessibilityEventData(
 object EventStore {
     private val events = ConcurrentLinkedDeque<AccessibilityEventData>()
     private val lock = Any()
-    var maxCapacity: Int = 200
-    var streamingEnabled: Boolean = false
+    @Volatile var maxCapacity: Int = 200
+    @Volatile var streamingEnabled: Boolean = false
 
     fun add(event: AccessibilityEvent) {
         val entry = AccessibilityEventData(

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
@@ -24,7 +24,7 @@ object NotificationStore {
 
     private val notifications = ConcurrentLinkedDeque<NotificationEntry>()
     private val lock = Any()
-    var maxCapacity: Int = 50
+    @Volatile var maxCapacity: Int = 50
 
     fun add(entry: NotificationEntry) {
         synchronized(lock) {


### PR DESCRIPTION
## What was fixed

Three plain `var` fields on singleton objects were missing `@Volatile`, risking stale reads across threads on ARM (Android's primary architecture). The JVM guarantees atomicity for boolean/int writes but not **visibility** without volatile or synchronization.

### Affected fields

| Field | Writer thread | Reader thread |
|-------|--------------|---------------|
| `EventStore.streamingEnabled` | `setStreaming()` on Dispatchers.IO (CommandDispatcher) | dispatch response building in CommandDispatcher (relay thread) |
| `EventStore.maxCapacity` | (read inside synchronized — lock provides visibility, but @Volatile added for defense-in-depth and parity) | |
| `NotificationStore.maxCapacity` | `BridgeNotificationListener` (notification listener thread) | `add()` inside synchronized |

### Sibling-implementation check

Grepped the bridge module for `maxCapacity` / `streamingEnabled`. Found `NotificationStore.maxCapacity` had the identical pattern (written from `BridgeNotificationListener.kt:26` outside any sync) — fixed here for parity.

## What was checked
- [x] Full file read before editing
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew compileDebugUnitTestKotlin` — BUILD SUCCESSFUL
- [x] CI runs `testDebugUnitTest` so existing tests cover the change
- [x] Sibling-implementation parity check across the bridge module

Audit findings: hermes-android EventStore.streamingEnabled (medium), plus sibling NotificationStore.maxCapacity