### PR TITLE
auto: call stop_relay() on daemon shutdown for graceful cleanup

### DIFF
--- a/contrib/hermes-relay-daemon.py
+++ b/contrib/hermes-relay-daemon.py
@@ -30,7 +30,7 @@ def main():
     if os.path.isdir(tools_dir):
         sys.path.insert(0, parent_dir)
 
-    from tools.android_relay import start_relay
+    from tools.android_relay import start_relay, stop_relay
 
     start_relay(pairing_code=pairing_code, port=port)
     logger.info("Relay started on port %d with pairing code ****", port)
@@ -45,6 +45,7 @@ def main():
     signal.signal(signal.SIGINT, handle_signal)
 
     stop_event.wait()
+    stop_relay()
     logger.info("Daemon exiting")
 
 


### PR DESCRIPTION
## What was fixed

The relay daemon (`contrib/hermes-relay-daemon.py`) caught SIGTERM/SIGINT, set `stop_event`, then exited **without calling `stop_relay()`**. This killed the relay thread abruptly, skipping cleanup of the aiohttp server (`runner.cleanup()`) and leaving WebSocket connections dangling.

The fix adds `stop_relay()` after `stop_event.wait()` returns, which:
- Signals the asyncio event loop to shut down
- Joins the relay thread with a 5s timeout
- Ensures aiohttp server + WebSocket connections are cleaned up

## What was checked
- [x] `stop_relay()` verified to exist at `tools/android_relay.py:109`
- [x] `python3 -m py_compile` passes
- [x] Existing relay tests pass: 14 passed (tests/test_android_relay.py)
- [x] No debug prints, no commented code, no TODOs

Audit finding: hermes-android relay daemon doesn't call stop_relay() (low severity)