### PR TITLE
auto: add @Volatile to DeviceCapabilities.hasTelephony

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/model/DeviceCapabilities.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/model/DeviceCapabilities.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 
 object DeviceCapabilities {
 
+    @Volatile
     var hasTelephony: Boolean = false
         private set
 


### PR DESCRIPTION
## Fix
`hasTelephony` is written during `init()` (called from `BridgeApplication.onCreate` on the main thread) and read from coroutine threads (e.g. `CommandDispatcher` dispatching `/send_sms`, `/call`, `/contacts`). Without `@Volatile`, the write may not be visible to other threads.

## Change
Added `@Volatile` annotation. Same visibility pattern recently fixed for `EventStore.maxCapacity`, `EventStore.streamingEnabled`, and `NotificationStore.maxCapacity`.

## Checked
- Sibling-implementation check: confirmed `@Volatile` is the established pattern for cross-thread mutable state in this repo (recent commit 2e3960a)
- `compileDebugKotlin` passes locally