### PR TITLE
auto: replace hashCode() with SHA-256 in ScreenNode.computeHash

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/model/ScreenNode.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/model/ScreenNode.kt
@@ -23,7 +23,8 @@ data class NodeBounds(val left: Int, val top: Int, val right: Int, val bottom: I
 fun ScreenNode.computeHash(): String {
     val childHashes = children.joinToString(",") { it.computeHash() }
     val raw = "$nodeId|$text|$contentDescription|$className|$clickable|$focusable|$scrollable|$editable|$checked|$childHashes"
-    return Integer.toHexString(raw.hashCode())
+    val digest = java.security.MessageDigest.getInstance("SHA-256").digest(raw.toByteArray(Charsets.UTF_8))
+    return digest.copyOfRange(0, 4).joinToString("") { "%02x".format(it) }
 }
 
 data class ActionResult(


### PR DESCRIPTION
## Fix
Replace `Integer.toHexString(raw.hashCode())` with a truncated SHA-256 digest in `ScreenNode.computeHash()`.

## Why
Kotlin/JVM `String.hashCode()` is a 32-bit non-cryptographic hash with high collision potential for UI tree comparison. In a security-sensitive remote-control bridge, hash collisions between distinct screen node trees could cause the diff/caching layer to wrongly consider two different screens identical — potentially skipping accessibility state changes.

SHA-256 with 4-byte (32-bit) truncation gives the same 8-char hex output length while eliminating the deterministic hashCode collision class of bugs.

## Review Notes
- **Callers**: `computeHash()` is called from `ActionExecutor.kt` (lines 403, 670) for screen state comparison — output format (hex string) is preserved, so callers need no changes.
- **Performance**: SHA-256 via `MessageDigest` is negligible overhead for the typical screen node tree size (dozens of nodes). The recursion structure is unchanged.
- **No new deps**: Uses `java.security.MessageDigest` (JDK standard).

## Files Changed
- `hermes-android-bridge/.../model/ScreenNode.kt` — `computeHash()` only