### PR TITLE
fix: remove unconditional clearProjectionPermission from ScreenRecorder finally block

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
@@ -135,7 +135,6 @@ object ScreenRecorder {
                     if (projectionCallback != null) projection?.unregisterCallback(projectionCallback)
                 } catch (_: Exception) {}
                 try { projection?.stop() } catch (_: Exception) {}
-                if (projection != null) clearProjectionPermission()
                 latch.countDown()
             }
         }


### PR DESCRIPTION
## What was fixed

ScreenRecorder.record() unconditionally called `clearProjectionPermission()` in the `finally` block (line 138) after every recording — even on successful captures. On Android < 14, the MediaProjection permission token is reusable across recordings. Clearing it forces the user to re-grant screen recording permission before every single `/screen_record` call.

## Fix

Removed the `clearProjectionPermission()` call from the `finally` block. It remains in the `catch` block (line 130) for `SecurityException`/`IllegalStateException` — the only cases where the token is actually invalidated by the system.

## What was checked
- Sibling-implementation check: `grep -rn clearProjectionPermission` — only 2 references (definition + catch-block call). No other call sites.
- `assembleDebug` builds clean.
- No test files added (existing CI runs `testDebugUnitTest` + `assembleDebug`; the change is a single-line deletion with no new code paths).