### PR TITLE
auto: fix NotificationStore tombstone accumulation

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
@@ -16,8 +16,7 @@ data class NotificationEntry(
     val category: String?,
     val timestamp: Long,
     val isOngoing: Boolean,
-    val isClearable: Boolean,
-    var removed: Boolean = false
+    val isClearable: Boolean
 )
 
 object NotificationStore {
@@ -37,13 +36,13 @@ object NotificationStore {
 
     fun getAll(limit: Int = 50): List<NotificationEntry> {
         synchronized(lock) {
-            return notifications.filter { !it.removed }.take(limit)
+            return notifications.take(limit)
         }
     }
 
     fun getSince(sinceTimestamp: Long, limit: Int = 50): List<NotificationEntry> {
         synchronized(lock) {
-            return notifications.filter { !it.removed && it.timestamp > sinceTimestamp }.take(limit)
+            return notifications.filter { it.timestamp > sinceTimestamp }.take(limit)
         }
     }
 
@@ -55,7 +54,7 @@ object NotificationStore {
 
     fun markRemoved(key: String) {
         synchronized(lock) {
-            notifications.find { it.key == key }?.removed = true
+            notifications.removeIf { it.key == key }
         }
     }
 


### PR DESCRIPTION
## What was fixed

`NotificationStore.markRemoved()` set `removed = true` on entries but left them in the `ConcurrentLinkedDeque`. Tombstoned entries persisted indefinitely and counted toward `maxCapacity` (100). Over time, the deque filled with dead entries, evicting live notifications while tombstones wasted capacity in the middle.

**Fix:** `markRemoved()` now physically removes entries via `removeIf { it.key == key }`. The `removed` field has been removed from `NotificationEntry` entirely — it was internal-only (not in `toMap`, not constructed by any caller), so `getAll` and `getSince` no longer filter on it.

## What was checked
- **Sibling-implementation check:** Grepped the entire repo for `.removed` references — no external code references the field (not in `CommandDispatcher`, `BridgeNotificationListener`, or tests)
- **Build gate:** `./gradlew assembleDebug` passes (BUILD SUCCESSFUL)
- **CI runs unit tests:** `.github/workflows/build.yml` runs `testDebugUnitTest` before `assembleDebug`
- `parseNotification()` already constructs `NotificationEntry` without the `removed` field — no call-site changes needed