### PR TITLE
auto: replace ConcurrentLinkedDeque with ArrayDeque in EventStore and NotificationStore

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
@@ -1,7 +1,6 @@
 package com.hermesandroid.bridge.event
 
 import android.view.accessibility.AccessibilityEvent
-import java.util.concurrent.ConcurrentLinkedDeque
 
 data class AccessibilityEventData(
     val eventType: String,
@@ -14,7 +13,7 @@ data class AccessibilityEventData(
 )
 
 object EventStore {
-    private val events = ConcurrentLinkedDeque<AccessibilityEventData>()
+    private val events = ArrayDeque<AccessibilityEventData>()
     private val lock = Any()
     @Volatile var maxCapacity: Int = 200
     @Volatile var streamingEnabled: Boolean = false

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/notification/NotificationStore.kt
@@ -3,7 +3,6 @@ package com.hermesandroid.bridge.notification
 import android.app.Notification
 import android.os.Bundle
 import android.service.notification.StatusBarNotification
-import java.util.concurrent.ConcurrentLinkedDeque
 
 data class NotificationEntry(
     val key: String,
@@ -22,7 +21,7 @@ data class NotificationEntry(
 
 object NotificationStore {
 
-    private val notifications = ConcurrentLinkedDeque<NotificationEntry>()
+    private val notifications = ArrayDeque<NotificationEntry>()
     private val lock = Any()
     @Volatile var maxCapacity: Int = 50
 


### PR DESCRIPTION
## What was fixed

Both `EventStore` and `NotificationStore` used `ConcurrentLinkedDeque` but wrapped **every** access in `synchronized(lock)`. The concurrent data structure provided no benefit — all thread safety came from the explicit lock.

Replaced with `ArrayDeque` — simpler, less per-node overhead, and communicates intent more clearly.

## Verified

- ✅ `./gradlew assembleDebug` — BUILD SUCCESSFUL (only pre-existing warnings)
- ✅ Sibling check: searched repo for `ConcurrentLinkedDeque` — no other Kotlin source usages (only CHANGELOG.md historical reference)
- ✅ `ArrayDeque` provides identical API surface (`addFirst`, `removeLast`, `size`, `take()`, `filter {}`, `find {}`, `clear()`)
- ✅ 4-line diff across 2 files, zero behavioral change