### PR TITLE
fix(tools): restrict .env to 0o600 after writing pairing token

### DIFF
--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -865,6 +865,11 @@ def _update_env_file(env_path, key: str, value: str):
             lines[-1] += "\n"
         lines.append(f"{key}={value}\n")
     env_path.write_text("".join(lines), encoding="utf-8")
+    # Restrict permissions: .env may contain the pairing token (full device access).
+    try:
+        env_path.chmod(0o600)
+    except OSError:
+        pass
 
 
 # ── Schema definitions ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What was fixed

`_update_env_file()` writes `ANDROID_BRIDGE_TOKEN` (the pairing code granting full device control) to `~/.hermes/.env` without setting restrictive file permissions. On systems with a permissive umask, other users on the host could read the token.

Now `chmod 0o600` is applied after every write to `_update_env_file()`.

## What was checked
- Sibling search: `_update_env_file` is the only writer in this repo. The primary path uses `hermes_cli.config.save_env_value()` (out of scope — different repo).
- `os` is already imported at the top of the file.
- Python syntax validated (`ast.parse`).
- CI (`build.yml`) only triggers on `hermes-android-bridge/**` path changes — this Python-only change does not affect the APK build.

## Audit reference
`hermes-android.json` → 'android_setup writes pairing code to .env file in plaintext'