### PR TITLE
fix(bridge): add @Volatile to ActionExecutor.tts and ttsReady

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -786,8 +786,8 @@ object ActionExecutor {
         return null
     }
 
-    private var tts: android.speech.tts.TextToSpeech? = null
-    private var ttsReady = false
+    @Volatile private var tts: android.speech.tts.TextToSpeech? = null
+    @Volatile private var ttsReady = false
 
     private suspend fun ensureTts(): Boolean {
         val service = BridgeAccessibilityService.instance ?: return false


### PR DESCRIPTION
## What was fixed

`ActionExecutor.tts` and `ttsReady` are shared mutable singleton fields accessed from multiple threads:
- **Writes**: `ensureTts()` / `speak()` on `Dispatchers.Main`
- **Writes**: `shutdownTts()` called from `BridgeAccessibilityService.onDestroy()`

Without `@Volatile`, the JVM memory model does not guarantee visibility of writes across threads — a thread may serve a cached stale value.

## What was checked
- **Sibling implementation check**: grepped for other `tts`/`ttsReady` declarations — only one site in `ActionExecutor`.
- **Pattern parity**: matches the fix applied to `EventStore.streamingEnabled` and `NotificationStore.maxCapacity` in PR #57.
- **Build gate**: `./gradlew assembleDebug` → BUILD SUCCESSFUL (warnings are pre-existing deprecation notices, unrelated).

## Audit reference
`hermes-android.json` → 'ActionExecutor.tts is a shared mutable singleton without synchronization'