### PR TITLE
auto: add @Volatile to ScreenRecorder projection fields for cross-thread visibility

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
@@ -18,8 +18,8 @@ object ScreenRecorder {
         "No MediaProjection. Grant Screen Recording in the app before each capture on Android 16."
     private const val MAX_DURATION_MS = 30_000L
 
-    private var projectionResultCode: Int? = null
-    private var projectionData: Intent? = null
+    @Volatile private var projectionResultCode: Int? = null
+    @Volatile private var projectionData: Intent? = null
     private var recorder: MediaRecorder? = null
     private var virtualDisplay: VirtualDisplay? = null
     private val handlerThread = HandlerThread("ScreenRecorder").apply { start() }


### PR DESCRIPTION
## What was fixed
Added `@Volatile` to `projectionResultCode` and `projectionData` in `ScreenRecorder.kt`.

These fields are written from the main thread (`MainActivity.onActivityResult → setProjectionPermission`) and read from `Dispatchers.IO` / `HandlerThread` (`record()`). Without `@Volatile`, there is no happens-before guarantee that the reading thread will see the latest write — a technically incorrect data race for security-critical state (MediaProjection permission tokens).

## What was checked
- `assembleDebug` build passed
- Sibling check: `recorder` and `virtualDisplay` are only accessed within `handler.post {}` (single-threaded) — no `@Volatile` needed there
- No other object fields are written/read cross-thread without synchronization
- Single-file, 2-line change