### PR TITLE
auto: replace LIMIT-in-sortOrder with application-level limit in searchContacts

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -592,11 +592,11 @@ object ActionExecutor {
                 android.provider.ContactsContract.Contacts._ID,
                 android.provider.ContactsContract.Contacts.DISPLAY_NAME
             )
-            val cursor = service.contentResolver.query(uri, projection, null, null, "${android.provider.ContactsContract.Contacts.DISPLAY_NAME} ASC LIMIT $safeLimit")
+            val cursor = service.contentResolver.query(uri, projection, null, null, "${android.provider.ContactsContract.Contacts.DISPLAY_NAME} ASC")
             cursor?.use {
                 val idIdx = it.getColumnIndex(android.provider.ContactsContract.Contacts._ID)
                 val nameIdx = it.getColumnIndex(android.provider.ContactsContract.Contacts.DISPLAY_NAME)
-                while (it.moveToNext()) {
+                while (it.moveToNext() && results.size < safeLimit) {
                     val contactId = it.getString(idIdx) ?: continue
                     val name = it.getString(nameIdx) ?: continue
                     val phoneNumbers = mutableListOf<String>()


### PR DESCRIPTION
## Summary

Moves the result cap from SQLite-level `LIMIT` in the `sortOrder` parameter to application-level counting via a `while` loop guard.

## Problem

The previous implementation embedded `LIMIT $safeLimit` inside the `sortOrder` argument passed to `ContentResolver.query()`. While this works on some Android versions, embedding `LIMIT` in the sort string is not part of the documented contract and can fail silently on certain OEM builds.

## Fix

- Removed `LIMIT $safeLimit` from the `sortOrder` parameter — now just `DISPLAY_NAME ASC`.
- Added `results.size < safeLimit` guard to the cursor iteration loop, enforcing the limit at the application level.
- The per-contact phone-number sub-query is now only triggered for contacts that actually make it into the results, which is more efficient when the contact DB has many matches.

## Review Notes

- **Phase 5.5 (sibling check):** `searchContacts` is called from `CommandDispatcher.kt:306` — no signature change, no impact. The Python tool `android_search_contacts` just passes `limit` through the relay, also unaffected.
- **Security:** No injection risk — `safeLimit` is an `Int` from `coerceAtMost(100).coerceAtLeast(1)`, never string-interpolated into SQL now.
- **Edge case:** Empty results handled (returns `"No contacts found"`).