### PR TITLE
auto: fix double-recycle of AccessibilityNodeInfo roots in ScreenReader.findNodeByText

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ScreenReader.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ScreenReader.kt
@@ -89,8 +89,12 @@ object ScreenReader {
             root.recycle()
         }
         // Recycle remaining unprocessed roots after early break
-        for (i in (foundIndex + 1) until roots.size) {
-            roots[i].recycle()
+        // Guard: when no match is found (foundIndex == -1), all roots were already
+        // recycled in the loop above — the cleanup would re-recycle them.
+        if (foundIndex >= 0) {
+            for (i in (foundIndex + 1) until roots.size) {
+                roots[i].recycle()
+            }
         }
         windows.forEach { it.recycle() }
         return found


### PR DESCRIPTION
## Fix
When `findNodeByText()` finds no matching node, `foundIndex` remains `-1`. The cleanup loop at line 92 iterates from `(foundIndex + 1) = 0`, re-recycling all roots that were already recycled in the main loop (lines 86-89).

While `AccessibilityNodeInfo.recycle()` is idempotent on most Android versions, this is a correctness bug — the cleanup loop should only run when a match was actually found (i.e., we broke out of the main loop early with roots remaining).

## Change
Guarded the cleanup loop with `if (foundIndex >= 0)`.

## Verification
- ✅ `./gradlew assembleDebug` passes
- ✅ Single file, 6 insertions / 2 deletions
- ✅ No new imports, no behavior change when a match IS found