### PR TITLE
auto: apply chmod(0o600) security fix to plugin copy of android_tool.py

### DIFF
--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -838,6 +838,11 @@ def _update_env_file(env_path, key: str, value: str):
             lines[-1] += "\n"
         lines.append(f"{key}={value}\n")
     env_path.write_text("".join(lines), encoding="utf-8")
+    # Restrict permissions: .env may contain the pairing token (full device access).
+    try:
+        env_path.chmod(0o600)
+    except OSError:
+        pass
 
 
 # ── Schema definitions ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What was fixed

The `tools/android_tool.py` copy got the `env_path.chmod(0o600)` fix in PR #64, but the **production copy** at `hermes-android-plugin/android_tool.py` was missing it. The file header explicitly states to keep both files in sync.

Without this fix, `~/.hermes/.env` is written with default permissions, potentially leaking the `ANDROID_BRIDGE_TOKEN` (full device access credential) to other local users.

## What was checked
- Sibling-implementation parity: verified `tools/android_tool.py` has the identical fix
- Python syntax compile passes
- CI runs `testDebugUnitTest` + `assembleDebug` on the Kotlin bridge only — this Python file is not covered by CI builds, but py_compile confirms no syntax errors
