### PR TITLE
auto: document EventStore eviction direction (ArrayDeque ring buffer)

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/event/EventStore.kt
@@ -48,6 +48,8 @@ object EventStore {
         )
 
         synchronized(lock) {
+            // ArrayDeque: head=newest (addFirst), tail=oldest (removeLast).
+            // removeLast drops the oldest entry to make room for the new one.
             if (events.size >= maxCapacity) {
                 events.removeLast()
             }


### PR DESCRIPTION
## What was fixed

EventStore.add() evicts the oldest entry via `removeLast()` before prepending the new one with `addFirst()`. This is correct behavior for a ring buffer, but the deque direction (head=newest, tail=oldest) was undocumented — making the eviction logic non-obvious to future readers.

Adds a comment explaining the deque direction and why `removeLast` drops the oldest entry.

## What was checked
- File exists on current main (pre-flight verified)
- 1 file changed, 2 lines added (comment only, no behavioral change)
- `assembleDebug` BUILD SUCCESSFUL
- No test additions needed (comment-only change)