### PR TITLE
fix(bridge): add @Volatile to ScreenRecorder.recorder and virtualDisplay

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/media/ScreenRecorder.kt
@@ -20,8 +20,8 @@ object ScreenRecorder {
 
     @Volatile private var projectionResultCode: Int? = null
     @Volatile private var projectionData: Intent? = null
-    private var recorder: MediaRecorder? = null
-    private var virtualDisplay: VirtualDisplay? = null
+    @Volatile private var recorder: MediaRecorder? = null
+    @Volatile private var virtualDisplay: VirtualDisplay? = null
     private val handlerThread = HandlerThread("ScreenRecorder").apply { start() }
     private val handler = Handler(handlerThread.looper)
 


### PR DESCRIPTION
## What was fixed

`recorder` and `virtualDisplay` fields in `ScreenRecorder.kt` were missing `@Volatile` despite being accessed across threads:

- **Written** on the HandlerThread inside `handler.post {}` (recording setup, teardown) and via `projectionCallback.onStop()`
- **Read/cleared** in `cleanupRecording()` which is called from `release()` — invocable from any thread

Without `@Volatile`, writes made on the HandlerThread may not be visible to a thread calling `release()`, risking use-after-free or double-release of `MediaRecorder`/`VirtualDisplay`.

The sibling fields `projectionResultCode` and `projectionData` already have `@Volatile` for the same cross-thread visibility reason. This completes the pattern.

## What was checked
- Sibling fields verified: `projectionResultCode` and `projectionData` already have `@Volatile` (commit 72d4140)
- `cleanupRecording()` is the only consumer of these fields — no other readers need parity changes
- `assembleDebug` build passes