### PR TITLE
fix(bridge): recycle match-index root in findNodeById to prevent AccessibilityNodeInfo leak

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -685,6 +685,7 @@ object ActionExecutor {
             val matches = findNodeByIdInTree(root, nodeId, "$wi")
             if (matches.isNotEmpty()) {
                 found = matches.first()
+                if (found !== roots[wi]) roots[wi].recycle()
                 for (r in roots.subList(wi + 1, roots.size)) r.recycle()
                 break
             }

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/executor/ActionExecutorRecycleTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/executor/ActionExecutorRecycleTest.kt
@@ -1,8 +1,10 @@
 package com.hermesandroid.bridge.executor
 
 import android.accessibilityservice.AccessibilityService
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
 import com.hermesandroid.bridge.service.BridgeAccessibilityService
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
@@ -10,11 +12,16 @@ import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 /**
  * Regression tests ensuring AccessibilityNodeInfo objects are always recycled,
  * preventing resource leaks in the long-running accessibility service.
  */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
 class ActionExecutorRecycleTest {
 
     private lateinit var mockService: BridgeAccessibilityService
@@ -104,5 +111,83 @@ class ActionExecutorRecycleTest {
 
         verify { node.recycle() }
         assertTrue(result.success)
+    }
+
+    /**
+     * Regression test for findNodeById root-recycle leak (medium severity).
+     *
+     * When the matching node is a CHILD (not the root), the root at the match
+     * index was never recycled — only subsequent roots via subList. The sibling
+     * ScreenReader.findNodeByText already handled this with `if (result !== root) root.recycle()`.
+     * findNodeById omitted the same guard, leaking ancestor AccessibilityNodeInfo
+     * objects over the long-running service lifetime.
+     *
+     * This test exercises findNodeById via the public describeNode(nodeId) entry
+     * point with a 2-window setup where window 0 has no match and window 1's root
+     * contains a matching child node. The root of window 1 must be recycled.
+     */
+    @Test
+    fun `describeNode recycles match-index root when found node is a child`() {
+        // Window 0: root with no matching child.
+        val root0 = mockk<AccessibilityNodeInfo>(relaxed = true)
+        every { root0.packageName } returns "com.app"
+        every { root0.className } returns "android.widget.FrameLayout"
+        every { root0.childCount } returns 0
+        every { root0.getBoundsInScreen(any()) } answers { /* no-op */ }
+
+        // Window 1: root whose child matches the target id.
+        val root1 = mockk<AccessibilityNodeInfo>(relaxed = true)
+        val child1 = mockk<AccessibilityNodeInfo>(relaxed = true)
+        every { root1.packageName } returns "com.app"
+        every { root1.className } returns "android.widget.FrameLayout"
+        every { root1.childCount } returns 1
+        every { root1.getChild(0) } returns child1
+        every { root1.getBoundsInScreen(any()) } answers { /* no-op */ }
+
+        // Child has the matching id and no children of its own.
+        every { child1.packageName } returns "com.app"
+        every { child1.className } returns "android.widget.Button"
+        every { child1.childCount } returns 0
+        every { child1.getBoundsInScreen(any()) } answers {
+            val r = it.invocation.args[0] as Rect
+            r.set(0, 0, 100, 100)
+        }
+
+        // Root0 and root1 bounds: give them distinct non-matching bounds so their
+        // computed ids differ from the child target.
+        every { root0.getBoundsInScreen(any()) } answers {
+            val r = it.invocation.args[0] as Rect
+            r.set(10, 10, 200, 200)
+        }
+        every { root1.getBoundsInScreen(any()) } answers {
+            val r = it.invocation.args[0] as Rect
+            r.set(20, 20, 300, 300)
+        }
+
+        val win0 = mockk<AccessibilityWindowInfo>(relaxed = true)
+        val win1 = mockk<AccessibilityWindowInfo>(relaxed = true)
+        every { win0.root } returns root0
+        every { win1.root } returns root1
+        every { mockService.windows } returns listOf(win0, win1)
+
+        // Target id matches the child's computed id:
+        // "${packageName}_${className}_${path}_${left}_${top}_${right}_${bottom}"
+        // child1 is at path "1_0" (window 1, child 0), bounds (0,0,100,100).
+        val targetId = "com.app_android.widget.Button_1_0_0_0_100_100"
+
+        val result = ActionExecutor.describeNode(targetId)
+
+        assertTrue("describeNode should succeed — got: ${result.message}", result.success)
+        // root0 was searched first and had no match → recycled.
+        verify { root0.recycle() }
+        // root1 is at the match index; with the old bug it would never be recycled
+        // because `found` (the child) !== root1 and the subList only covers windows
+        // AFTER the match index. After the fix, root1 MUST be recycled.
+        verify { root1.recycle() }
+        // The matched child is recycled by describeNode after use.
+        verify { child1.recycle() }
+        // Windows are recycled by findNodeById.
+        verify { win0.recycle() }
+        verify { win1.recycle() }
     }
 }


### PR DESCRIPTION
## What was fixed

`findNodeById()` in `ActionExecutor.kt` leaked the `AccessibilityNodeInfo` root at the match index when the matching node was a **deep child** (`found !== root`). The `subList` recycle only covered windows *after* the match index, so the root holding the matched subtree was never recycled — accumulating leaks over the long-running accessibility service lifetime and eventually exhausting the system's finite `AccessibilityNodeInfo` pool.

## The fix

1-line guard added before the `subList` recycle:
```kotlin
if (found !== roots[wi]) roots[wi].recycle()
```

This mirrors the proven pattern already in `ScreenReader.findNodeByText` (line 86: `if (result !== root) root.recycle()`) — the sibling-implementation parity check confirms this is the established safe pattern in this codebase.

## What was checked

- [x] **Sibling-implementation parity**: `ScreenReader.findNodeByText` already handles this case correctly; `findNodeById` was the lone outlier.
- [x] **No behavior change when found IS the root**: the guard `found !== roots[wi]` skips the recycle when the match is the root itself (same as the sibling).
- [x] **Build gate**: `./gradlew clean assembleDebug testDebugUnitTest` — BUILD SUCCESSFUL, all tests pass.
- [x] **Regression test**: new Robolectric test `describeNode recycles match-index root when found node is a child` — **verified to fail without the fix** (root1 recycle never called) and pass with it.
- [x] **CI runs tests**: `.github/workflows/build.yml` runs `testDebugUnitTest` on every PR.

## Severity

Medium — silent resource leak in a long-running service, no crash but eventual degradation of accessibility operations.