### PR TITLE
auto: fix pinch gesture — perpendicular strokes instead of diagonal crossover

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -430,14 +430,19 @@ object ActionExecutor {
             ?: return@wakeForAction ActionResult(false, "Accessibility service not running")
         val centerX = x.toFloat()
         val centerY = y.toFloat()
-        val offset = 100f * scale
+        // Perpendicular strokes on opposite sides of center along the X axis.
+        // Fingers start at ±startOff and end at ±endOff. For scale>1 (zoom in),
+        // endOff > startOff so fingers move apart; for scale<1 (zoom out),
+        // endOff < startOff so fingers move together.
+        val startOff = 50f
+        val endOff = 50f * scale
         val path1 = Path().apply {
-            moveTo(centerX - offset, centerY - offset)
-            lineTo(centerX + offset, centerY + offset)
+            moveTo(centerX - startOff, centerY)
+            lineTo(centerX - endOff, centerY)
         }
         val path2 = Path().apply {
-            moveTo(centerX + offset, centerY + offset)
-            lineTo(centerX - offset, centerY - offset)
+            moveTo(centerX + startOff, centerY)
+            lineTo(centerX + endOff, centerY)
         }
         val stroke1 = GestureDescription.StrokeDescription(path1, 0, duration)
         val stroke2 = GestureDescription.StrokeDescription(path2, 0, duration)


### PR DESCRIPTION
## Problem
`pinch()` created two strokes along the SAME diagonal line traversed in opposite directions. Both fingers converged to center and crossed through it. The `scale` parameter only affected distance from center, not gesture direction — so the gesture was always a diagonal crossover regardless of scale value. Maps and photo galleries would not respond as expected.

## Fix
Replaced the diagonal paths with perpendicular strokes on opposite sides of center along the X axis:
- **Finger 1**: moves along (cx - startOff, cy) → (cx - endOff, cy)  [left side]
- **Finger 2**: moves along (cx + startOff, cy) → (cx + endOff, cy)  [right side]

Where `startOff = 50f` and `endOff = 50f * scale`:
- **scale > 1 (zoom in)**: endOff > startOff → fingers move apart
- **scale < 1 (zoom out)**: endOff < startOff → fingers move together

## Verification
- ✅ `./gradlew assembleDebug` — BUILD SUCCESSFUL
- Single-file change, no public API change

## Sibling check
Grepped for other pinch/gesture implementations — this is the only `pinch()` in the codebase. Other gesture methods (`click`, `longClick`, `drag`, `swipe`) use single-stroke paths and are unaffected.