### PR TITLE
auto: cancel previous WebSocket before reconnect to prevent stacked connections

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
@@ -160,6 +160,11 @@ object RelayClient {
                 notifyStatus(false, "Reconnecting in ${backoff / 1000}s... (attempt $retries/$MAX_RETRIES)")
                 delay(backoff)
                 if (shouldReconnect && !isConnected) {
+                    // Cancel the previous WebSocket before opening a new one,
+                    // otherwise its listener stays active and can fire
+                    // out-of-order callbacks (onOpen/onFailure) that set
+                    // isConnected or push duplicate status notifications.
+                    webSocket?.cancel()
                     doConnect(url, code)
                     delay(3000)
                     if (!isConnected) {


### PR DESCRIPTION
## Problem
In `scheduleReconnect()`, after calling `doConnect()` the code waited a fixed 3s then checked `isConnected`. If the WebSocket handshake took longer than 3s (possible on slow/high-latency networks), `isConnected` was still false, so the loop called `doConnect()` again — creating a new WebSocket that replaced the `webSocket` reference.

The previous WebSocket's listener remained active and would eventually fire `onOpen()` or `onFailure()`, potentially:
- Setting `isConnected = true` out of order
- Firing duplicate status notifications

Under sustained poor network conditions, multiple dead WebSockets piled up before their `onFailure` callbacks fired.

## Fix
Added `webSocket?.cancel()` before each retry `doConnect()` in the reconnect loop. This explicitly tears down the previous WebSocket and its listener before opening a new connection.

## Verification
- ✅ `./gradlew assembleDebug` — BUILD SUCCESSFUL
- Single-line addition, no behavioral change to the happy path

## Sibling check
This is the only WebSocket reconnect loop in the codebase. The `onClosed()` and `onFailure()` callbacks both call `scheduleReconnect()`, and the `reconnectJob?.cancel()` at the top of `scheduleReconnect()` ensures only one reconnect loop runs at a time — so there's no risk of multiple concurrent loops racing.