### PR TITLE
auto: recycle all AccessibilityNodeInfo roots in /current_app

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -142,10 +142,11 @@ object CommandDispatcher {
                 val result = withContext(Dispatchers.Main) {
                     val service = BridgeAccessibilityService.instance
                     val windows = service?.windows ?: emptyList()
-                    val root = windows.firstOrNull()?.root
-                    val pkg = root?.packageName?.toString() ?: "unknown"
-                    val cls = root?.className?.toString() ?: "unknown"
-                    root?.recycle()
+                    val roots = windows.mapNotNull { it.root }
+                    val firstRoot = roots.firstOrNull()
+                    val pkg = firstRoot?.packageName?.toString() ?: "unknown"
+                    val cls = firstRoot?.className?.toString() ?: "unknown"
+                    roots.forEach { it.recycle() }
                     windows.forEach { it.recycle() }
                     mapOf("package" to pkg, "className" to cls)
                 }


### PR DESCRIPTION
## Fix
The `/current_app` handler only obtained and recycled the first window's root (`windows.firstOrNull()?.root`). Roots from windows[1..n] were never obtained and thus never recycled — an accessibility resource leak.

## Change
Replaced single-root pattern with the same pattern used in `ScreenReader.readCurrentScreen()`:
```kotlin
val roots = windows.mapNotNull { it.root }
// use roots.firstOrNull() for package/className
roots.forEach { it.recycle() }
windows.forEach { it.recycle() }
```

## Sibling-implementation check
- `ScreenReader.readCurrentScreen()` (line 26): already uses `mapNotNull { it.root }` + `roots.forEach { it.recycle() }` — this fix achieves parity with that pattern
- `ScreenReader.findNodeById()` (line 77) and `readWidgets()` (line 129): same pattern — already correct
- Other `/current_app`-style endpoints do not access window roots

## Build
`./gradlew assembleDebug` — BUILD SUCCESSFUL (only pre-existing `recycle()` deprecation warnings, same as main)