### PR TITLE
auto: remove ?token= query string fallback from relay WS auth

### DIFF
--- a/tests/test_android_relay.py
+++ b/tests/test_android_relay.py
@@ -138,8 +138,9 @@ class TestBodyLogRedaction:
 
 
 class TestWsAuthHeader:
-    """Regression: WS handshake auth accepts a Bearer header (preferred — query
-    strings leak into reverse-proxy access logs) with ?token= as legacy fallback."""
+    """Regression: WS handshake auth accepts a Bearer header only. The ?token=
+    query string fallback was removed because it leaked pairing codes into
+    reverse-proxy access logs."""
 
     PORT = 19881
     CODE = "WSCODE"
@@ -165,9 +166,9 @@ class TestWsAuthHeader:
         start_relay(pairing_code=self.CODE, port=self.PORT)
         assert self._try_connect(headers={"Authorization": f"Bearer {self.CODE}"})
 
-    def test_legacy_query_token_accepted(self):
+    def test_query_token_rejected(self):
         start_relay(pairing_code=self.CODE, port=self.PORT)
-        assert self._try_connect(query=f"?token={self.CODE}")
+        assert not self._try_connect(query=f"?token={self.CODE}")
 
     def test_bad_bearer_header_rejected(self):
         start_relay(pairing_code=self.CODE, port=self.PORT)

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -386,13 +386,14 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
             text="Too many failed authentication attempts. Try again later."
         )
 
-    # Prefer the Authorization header (query strings leak into reverse-proxy
-    # access logs); fall back to ?token= for older APKs.
+    # Authorization header only — the ?token= query string fallback was removed
+    # because query strings are logged verbatim by reverse proxies (nginx,
+    # Cloudflare, Apache), leaking the pairing code into plaintext access logs.
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
         token = auth_header.removeprefix("Bearer ").strip()
     else:
-        token = request.query.get("token", "")
+        token = ""
     # Constant-time comparison to mitigate timing side-channel attacks that
     # could otherwise leak the pairing code byte-by-byte.
     # PairingManager generates uppercase-only codes — compare exact-case to


### PR DESCRIPTION
## What was fixed

Removed the `?token=` query string fallback from the relay WebSocket auth handler (`android_relay.py:395`). The fallback let older APKs authenticate by passing the pairing code as a URL query parameter, but query strings are logged verbatim by reverse proxies (nginx, Cloudflare, Apache), leaking the full device-access pairing code into plaintext access logs.

The Kotlin client (`RelayClient.kt:106`) always sends the `Authorization: Bearer` header now, so the fallback only activated for old APKs behind a proxy — a security liability with no current benefit.

## What was checked
- Target code verified to exist in current `main`
- `TestWsAuthHeader.test_legacy_query_token_accepted` → renamed to `test_query_token_rejected` and assertion flipped to verify the fallback is now rejected
- All 24 Python tests pass (`pytest tests/test_android_relay.py`)
- No other code in the repo uses `request.query.get("token")` — the Kotlin client uses the Bearer header exclusively