### PR TITLE
auto: increase screenshot JPEG quality from 50 to 80

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -250,7 +250,7 @@ object ActionExecutor {
                         val w = bitmap.width
                         val h = bitmap.height
                         val stream = ByteArrayOutputStream()
-                        bitmap.compress(Bitmap.CompressFormat.JPEG, 50, stream)
+                        bitmap.compress(Bitmap.CompressFormat.JPEG, 80, stream)
                         val base64 = Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
                         bitmap.recycle()
 


### PR DESCRIPTION
## What was fixed

Increased the screenshot JPEG compression quality from 50 to 80 in `ActionExecutor.takeScreenshot()` (line 253).

At quality 50, small text, icons, and fine UI details become artifacted and unreadable — making the agent's vision-based screen reading fallback (used when the accessibility tree lacks context) less effective and more likely to misinterpret screen content.

## What was checked
- `assembleDebug` build successful (BUILD SUCCESSFUL)
- Single-line change, no new imports needed
- The bandwidth increase is negligible relative to the relay's existing 2Mbps video stream