### PR TITLE
auto: add blocklist for dangerous broadcast actions in sendBroadcast

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -657,6 +657,30 @@ object ActionExecutor {
     fun sendBroadcast(action: String, extras: Map<String, String>? = null): ActionResult {
         val service = BridgeAccessibilityService.instance
             ?: return ActionResult(false, "Accessibility service not running")
+
+        // Block known-dangerous system broadcasts that can cause DoS or abuse
+        // device resources when fired from an unprivileged bridge context.
+        // Custom namespace actions (containing a dot) are allowed.
+        val blockedBroadcasts = setOf(
+            "android.intent.action.MEDIA_MOUNTED",
+            "android.intent.action.MEDIA_UNMOUNTED",
+            "android.intent.action.MEDIA_EJECT",
+            "android.intent.action.MEDIA_SCANNER_FINISHED",
+            "android.intent.action.MEDIA_SCANNER_SCAN_FILE",
+            "android.intent.action.PACKAGE_ADDED",
+            "android.intent.action.PACKAGE_REMOVED",
+            "android.intent.action.PACKAGE_REPLACED",
+            "android.intent.action.PACKAGE_DATA_CLEARED",
+            "android.intent.action.DEVICE_STORAGE_LOW",
+            "android.intent.action.DEVICE_STORAGE_OK"
+        )
+        if (action.isBlank()) {
+            return ActionResult(false, "Broadcast action is empty")
+        }
+        if (action in blockedBroadcasts) {
+            return ActionResult(false, "Broadcast action '$action' is blocked for safety")
+        }
+
         return try {
             val intent = Intent(action)
             extras?.forEach { (key, value) -> intent.putExtra(key, value) }


### PR DESCRIPTION
## What was fixed

Added a curated blocklist of known-dangerous system broadcast actions to `ActionExecutor.sendBroadcast()` (line 657). Previously, any authenticated relay client could fire arbitrary unprotected system broadcasts — including `MEDIA_MOUNTED` (triggers media scanning / battery drain), `PACKAGE_*` actions, and storage-level events. The bridge app runs with extensive permissions (accessibility, SMS, contacts, location), so broadcasts inherit those privileges.

Blocked actions:
- `android.intent.action.MEDIA_MOUNTED/UNMOUNTED/EJECT/SCANNER_*` — media scanning abuse
- `android.intent.action.PACKAGE_ADDED/REMOVED/REPLACED/DATA_CLEARED` — package manager abuse
- `android.intent.action.DEVICE_STORAGE_LOW/OK` — storage management triggers

Custom-namespace actions (app-level receivers) remain allowed.

Also added empty-action guard.

## What was checked
- `assembleDebug` build successful
- Sibling implementation checked: `CommandDispatcher.kt:325` routes `/broadcast` to `ActionExecutor.sendBroadcast()` — both paths covered by the blocklist
- Python tool `android_tool.py:741` (`android_broadcast()`) is a thin HTTP wrapper, no filtering needed there — the blocklist is enforced at the bridge level