### PR TITLE
auto: remove version from unauthenticated /ping response

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -3,7 +3,6 @@
 package com.hermesandroid.bridge.server
 
 import com.google.gson.JsonObject
-import com.hermesandroid.bridge.BuildConfig
 import com.hermesandroid.bridge.event.EventStore
 import com.hermesandroid.bridge.executor.ActionExecutor
 import com.hermesandroid.bridge.executor.ScreenReader
@@ -43,8 +42,10 @@ object CommandDispatcher {
                 mapOf(
                     "status" to "ok",
                     "accessibilityService" to serviceRunning,
-                    "authenticated" to authenticated,
-                    "version" to BuildConfig.VERSION_NAME
+                    "authenticated" to authenticated
+                    // Version omitted: /ping is unauthenticated and version info
+                    // helps attackers fingerprint the deployment and target known
+                    // vulnerabilities in specific versions.
                 ) to 200
             }
 


### PR DESCRIPTION
## What was fixed

Removed the `version` field (containing `BuildConfig.VERSION_NAME`) from the unauthenticated `/ping` endpoint response in `CommandDispatcher.kt:47`.

The `/ping` endpoint is intentionally accessible without auth for discovery, but version information helps an attacker fingerprint the deployment and target known vulnerabilities in specific versions. The pairing code brute-force surface is already exposed on 0.0.0.0:8765 — adding version info gives attackers a free reconnaissance data point.

Also removed the now-unused `import com.hermesandroid.bridge.BuildConfig` to avoid a compiler warning.

## What was checked
- `assembleDebug` build successful (BUILD SUCCESSFUL)
- Python tool (`android_tool.py`) does not reference version from `/ping` — no downstream breakage
- Discovery needs (status, accessibilityService, authenticated) are retained