### PR TITLE
auto: increase screen hash from 4 to 8 bytes of SHA-256 digest

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/model/ScreenNode.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/model/ScreenNode.kt
@@ -24,7 +24,7 @@ fun ScreenNode.computeHash(): String {
     val childHashes = children.joinToString(",") { it.computeHash() }
     val raw = "$nodeId|$text|$contentDescription|$className|$clickable|$focusable|$scrollable|$editable|$checked|$childHashes"
     val digest = java.security.MessageDigest.getInstance("SHA-256").digest(raw.toByteArray(Charsets.UTF_8))
-    return digest.copyOfRange(0, 4).joinToString("") { "%02x".format(it) }
+    return digest.copyOfRange(0, 8).joinToString("") { "%02x".format(it) }
 }
 
 data class ActionResult(


### PR DESCRIPTION
## What

Bumps `ScreenNode.computeHash()` from 4 bytes (8 hex chars / 32-bit) to 8 bytes (16 hex chars / 64-bit) of the SHA-256 digest.

## Why

The screen hash is used by `/screen_hash` and `/diff_screen` for change detection. A 32-bit hash space has a non-trivial collision probability (~1 in 4 billion) — unlikely but possible with repeated polling across many screen states. Doubling to 64-bit makes accidental collisions negligible.

## Review notes

- **Callers**: `ActionExecutor.screenHash()` (line 675) and `ActionExecutor.diffScreen()` (line 403) both treat the hash as an opaque string — no length assumptions.
- **Python layer**: `android_screen_hash()` / `android_diff_screen()` pass the hash through as an opaque string. No parsing of hash length.
- **Tests**: `TestScreenHash` mocks the hash value; no length assertions. No breakage.
- **No sibling implementations**: `computeHash()` is defined once in `ScreenNode.kt`.

🤖 Generated with [Hermes PR Pipeline](https://hermes-agent.nousresearch.com)