### PR TITLE
auto: remove ?token= query fallback from plugin android_relay.py (security)

### DIFF
--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -383,13 +383,14 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
             text="Too many failed authentication attempts. Try again later."
         )
 
-    # Prefer the Authorization header (query strings leak into reverse-proxy
-    # access logs); fall back to ?token= for older APKs.
+    # Authorization header only — the ?token= query string fallback was removed
+    # because query strings are logged verbatim by reverse proxies (nginx,
+    # Cloudflare, Apache), leaking the pairing code into plaintext access logs.
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
         token = auth_header.removeprefix("Bearer ").strip()
     else:
-        token = request.query.get("token", "")
+        token = ""
     # Constant-time comparison to mitigate timing side-channel attacks that
     # could otherwise leak the pairing code byte-by-byte.
     # PairingManager generates uppercase-only codes — compare exact-case to


### PR DESCRIPTION
## What was fixed

The `?token=` query string fallback was removed from `tools/android_relay.py` in PR #78 because query strings are logged verbatim by reverse proxies (nginx, Cloudflare, Apache), leaking the pairing code into plaintext access logs.

**However, the same fix was NOT propagated to `hermes-android-plugin/android_relay.py:392`** — the PRODUCTION copy that gets installed into hermes-agent. The plugin copy still had `token = request.query.get("token", "")`, meaning the pairing code (which grants full remote device control) was still leaking in production deployments.

## Fix

Identical to `tools/android_relay.py` (PR #78):
- Replaced `token = request.query.get("token", "")` with `token = ""`
- Updated the comment to match the tools/ copy exactly

## Verification

- `py_compile` passes
- All 24 existing Python tests pass (`pytest tests/test_android_relay.py`)
- Diff matches the already-merged tools/ fix line-for-line
- Sibling-implementation check: confirmed only 1 occurrence of query-string token in the plugin file