### PR TITLE
auto: URL-encode searchContacts query (URI injection prevention)

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -592,7 +592,8 @@ object ActionExecutor {
         }
         return try {
             val results = mutableListOf<Map<String, String?>>()
-            val uri = android.net.Uri.withAppendedPath(android.provider.ContactsContract.Contacts.CONTENT_FILTER_URI, query)
+            val safeQuery = android.net.Uri.encode(query)
+            val uri = android.net.Uri.withAppendedPath(android.provider.ContactsContract.Contacts.CONTENT_FILTER_URI, safeQuery)
             val projection = arrayOf(
                 android.provider.ContactsContract.Contacts._ID,
                 android.provider.ContactsContract.Contacts.DISPLAY_NAME


### PR DESCRIPTION
## What was fixed

`ActionExecutor.searchContacts()` appended the raw query string to `ContactsContract.Contacts.CONTENT_FILTER_URI` via `Uri.withAppendedPath()` without URL-encoding. If the query contains URI-special characters (`/`, `#`, `?`), this can break the content URI or cause unexpected query behavior.

The Python side (`android_tool.py:713`) already URL-encodes the query via `quote(query)`, but the Kotlin side received it decoded and passed it raw to the content resolver.

## Fix

Added `Uri.encode(query)` before appending to the filter URI:

```kotlin
val safeQuery = android.net.Uri.encode(query)
val uri = Uri.withAppendedPath(Contacts.CONTENT_FILTER_URI, safeQuery)
```

`Uri.encode()` is the standard Android API for encoding path segments — handles `/`, `#`, `?`, spaces, and all reserved characters.

## Verification

- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- Sibling check: this is the only `withAppendedPath` call in the file