### PR TITLE
auto: add system-destructive broadcasts to blocklist (shutdown/master_clear/factory_reset)

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -673,7 +673,10 @@ object ActionExecutor {
             "android.intent.action.PACKAGE_REPLACED",
             "android.intent.action.PACKAGE_DATA_CLEARED",
             "android.intent.action.DEVICE_STORAGE_LOW",
-            "android.intent.action.DEVICE_STORAGE_OK"
+            "android.intent.action.DEVICE_STORAGE_OK",
+            "android.intent.action.ACTION_SHUTDOWN",
+            "android.intent.action.MASTER_CLEAR",
+            "android.intent.action.FACTORY_RESET"
         )
         if (action.isBlank()) {
             return ActionResult(false, "Broadcast action is empty")


### PR DESCRIPTION
## What was fixed

The `sendBroadcast` blocklist was missing critical system-destructive actions:
- `android.intent.action.ACTION_SHUTDOWN`
- `android.intent.action.MASTER_CLEAR`
- `android.intent.action.FACTORY_RESET`

While Android blocks these at the system level (protected broadcasts), explicit rejection provides clear feedback to the caller instead of a cryptic system error.

## What was checked
- Sibling implementation check: grepped repo for other `sendBroadcast` callers — only one implementation in ActionExecutor
- Build: `./gradlew assembleDebug` passes
- No new dependencies, no API changes, single-file change