### PR TITLE
auto: fix stale ?token= docstrings in android_relay.py

### DIFF
--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -2,13 +2,13 @@
 android_relay — WebSocket relay that bridges HTTP tool calls to a phone over WS.
 
 The relay runs an aiohttp server exposing:
-  - /ws          WebSocket endpoint the phone connects to (?token=CODE for auth)
+  - /ws          WebSocket endpoint the phone connects to (Authorization: Bearer *** header for auth)
   - /ping, /screen, /tap, /tap_text, /type, /swipe, /open_app, /press_key,
     /screenshot, /scroll, /wait, /apps, /current_app   HTTP endpoints matching
     the bridge API consumed by android_tool.py
 
 Flow:
-  1. Phone connects via WebSocket with ?token=<pairing_code>
+  1. Phone connects via WebSocket with Bearer token in Authorization header
   2. Python tool makes an HTTP request to e.g. /screen
   3. Relay wraps request as JSON command, sends over WS to phone
   4. Phone executes command, sends JSON response back over WS

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -2,13 +2,13 @@
 android_relay — WebSocket relay that bridges HTTP tool calls to a phone over WS.
 
 The relay runs an aiohttp server exposing:
-  - /ws          WebSocket endpoint the phone connects to (?token=CODE for auth)
+  - /ws          WebSocket endpoint the phone connects to (Authorization: Bearer *** header for auth)
   - /ping, /screen, /tap, /tap_text, /type, /swipe, /open_app, /press_key,
     /screenshot, /scroll, /wait, /apps, /current_app   HTTP endpoints matching
     the bridge API consumed by android_tool.py
 
 Flow:
-  1. Phone connects via WebSocket with ?token=<pairing_code>
+  1. Phone connects via WebSocket with Bearer token in Authorization header
   2. Python tool makes an HTTP request to e.g. /screen
   3. Relay wraps request as JSON command, sends over WS to phone
   4. Phone executes command, sends JSON response back over WS


### PR DESCRIPTION
## What was fixed

Both copies of `android_relay.py` (plugin and tools/) had module docstrings referencing `?token=CODE` / `?token=<pairing_code>` query string auth. The actual code was fixed in commit 26bde5b to use `Authorization: Bearer` header only — the `?token=` query string fallback was removed because query strings leak pairing codes into reverse-proxy access logs.

Stale docstrings could mislead a developer into thinking query-string auth is still supported and reintroducing the security issue.

## Changes
- `hermes-android-plugin/android_relay.py` lines 5, 11: updated docstring
- `tools/android_relay.py` lines 5, 11: updated docstring

## What was checked
- Verified both files use `Authorization: Bearer` header auth in code (lines 386-401)
- Confirmed remaining `?token=` references are: (a) code comments documenting the removal, (b) regression test verifying `?token=` auth is rejected
- Python syntax validated via `py_compile`
- Sibling-implementation check: grep confirmed both copies now have consistent docstrings