### PR TITLE
(bridge) sendIntent: denylist dangerous URI schemes incl. single-colon tel:/smsto:

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -663,6 +663,23 @@ object ActionExecutor {
         val intent = Intent(action).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             if (dataUri != null) {
+                // Denylist dangerous URI schemes that can bypass the action blocklist.
+                // An attacker can use a benign action like VIEW with a malicious URI
+                // (intent:// redirects, content:// providers, market:// deep links,
+                //  tel:, smsto:, mmsto:).
+                val blockedUriSchemes = setOf("intent", "market", "smsto", "mmsto", "tel")
+                val blockedUriPrefixes = listOf("content://settings", "content://com.android.contacts")
+                // Handle both standard schemes (http://, intent://) and single-colon
+                // schemes (tel:, smsto:, mmsto:). substringBefore("://") alone fails
+                // for single-colon URIs because "://" is absent, returning the full
+                // string (e.g. "tel:123456") instead of just "tel".
+                val scheme = dataUri.substringBefore("://").substringBefore(":").lowercase()
+                if (scheme in blockedUriSchemes) {
+                    return ActionResult(false, "URI scheme '$scheme://' is blocked for safety")
+                }
+                if (blockedUriPrefixes.any { dataUri.lowercase().startsWith(it) }) {
+                    return ActionResult(false, "Content provider URI is blocked for safety")
+                }
                 setData(android.net.Uri.parse(dataUri))
             }
             extras?.forEach { (key, value) ->

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/executor/ActionExecutorSendIntentTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/executor/ActionExecutorSendIntentTest.kt
@@ -110,4 +110,94 @@ class ActionExecutorSendIntentTest {
         assertTrue("expected success — got: ${result.message}", result.success)
         verify(exactly = 1) { mockService.startActivity(any()) }
     }
+
+    // ── URI scheme denylist tests ────────────────────────────────────────
+
+    @Test
+    fun `sendIntent blocks intent colon-slash-slash URI scheme`() {
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "intent://example.com/#Intent;scheme=http;end"
+        )
+        assertFalse(result.success)
+        assertTrue(result.message.contains("blocked for safety"))
+        verify(exactly = 0) { mockService.startActivity(any()) }
+    }
+
+    @Test
+    fun `sendIntent blocks market URI scheme`() {
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "market://details?id=com.example"
+        )
+        assertFalse(result.success)
+        assertTrue(result.message.contains("blocked for safety"))
+        verify(exactly = 0) { mockService.startActivity(any()) }
+    }
+
+    @Test
+    fun `sendIntent blocks tel single-colon URI scheme`() {
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "tel:1234567890"
+        )
+        assertFalse(result.success)
+        assertTrue(result.message.contains("blocked for safety"))
+        verify(exactly = 0) { mockService.startActivity(any()) }
+    }
+
+    @Test
+    fun `sendIntent blocks smsto single-colon URI scheme`() {
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "smsto:1234567890"
+        )
+        assertFalse(result.success)
+        assertTrue(result.message.contains("blocked for safety"))
+        verify(exactly = 0) { mockService.startActivity(any()) }
+    }
+
+    @Test
+    fun `sendIntent blocks mmsto single-colon URI scheme`() {
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "mmsto:1234567890"
+        )
+        assertFalse(result.success)
+        assertTrue(result.message.contains("blocked for safety"))
+        verify(exactly = 0) { mockService.startActivity(any()) }
+    }
+
+    @Test
+    fun `sendIntent blocks content colon-slash-slash settings URI prefix`() {
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "content://settings/system"
+        )
+        assertFalse(result.success)
+        assertTrue(result.message.contains("blocked for safety"))
+        verify(exactly = 0) { mockService.startActivity(any()) }
+    }
+
+    @Test
+    fun `sendIntent blocks content colon-slash-slash contacts URI prefix`() {
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "content://com.android.contacts/data/123"
+        )
+        assertFalse(result.success)
+        assertTrue(result.message.contains("blocked for safety"))
+        verify(exactly = 0) { mockService.startActivity(any()) }
+    }
+
+    @Test
+    fun `sendIntent allows benign http URI scheme`() {
+        every { mockService.startActivity(any()) } returns Unit
+        val result = ActionExecutor.sendIntent(
+            action = "android.intent.action.VIEW",
+            dataUri = "https://example.com"
+        )
+        assertTrue("expected success — got: ${result.message}", result.success)
+        verify(exactly = 1) { mockService.startActivity(any()) }
+    }
 }


### PR DESCRIPTION
## Problem

sendIntent previously validated only the *action* string against a denylist (PR #87). A benign action like `android.intent.action.VIEW` with a malicious `dataUri` could bypass that gate — `intent://` redirects, `market://` install flows, `content://settings` / `content://com.android.contacts` providers, and `tel:`/`smsto:`/`mmsto:` telephony triggers.

## Fix

Added a URI scheme denylist in `ActionExecutor.sendIntent` before `setData()`:

- **Scheme extraction fix:** `substringBefore("://")` alone fails for single-colon schemes (`tel:1234` has no `://`, so it returned the full string). Now chains `.substringBefore("://").substringBefore(":")` to correctly extract `tel`, `smsto`, `mmsto`, `intent`, `market`.
- **Blocked schemes:** `intent`, `market`, `smsto`, `mmsto`, `tel`
- **Blocked content prefixes:** `content://settings`, `content://com.android.contacts`

## Tests

8 new tests in `ActionExecutorSendIntentTest`:
- Blocks each scheme: intent://, market:, tel:, smsto:, mmsto:
- Blocks content://settings and content://com.android.contacts
- Allows benign https:// URI (no false positive)
- All assert startActivity is never reached (`verify(exactly = 0)`)

## Review

- Single entry point: `/intent` route in CommandDispatcher; both BridgeRouter (HTTP) and RelayClient (WebSocket) funnel through it, so the gate covers all transports.
- No signature changes, no new deps, denylist pattern mirrors existing sendIntent action block + sendBroadcast block conventions.