### PR TITLE
auto-fix: update AGENTS.md version string 0.3.0 → 0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ generic Project Defaults, Workflows) live in `AGENTS.base.md` — not duplicated
 ## Core
 - Repo: hermes-android. Two components: Kotlin bridge app (`hermes-android-bridge/`) + Python toolset (`tools/`, `tests/`, `hermes-android-plugin/`).
 - Python prod copy lives in hermes-agent repo; this repo = standalone dev/test. APK does NOT depend on Python.
-- Branch `main`. pyproject version 0.3.0.
+- Branch `main`. pyproject version 0.4.0.
 - Shipped = git tag (`latest-build` APK + version tag), not main merge.
 - Confidentiality: this is a remote-control bridge — security-sensitive. Full device access once paired. Never expose pairing codes, server IPs, tokens, screen content, screenshots, contacts/SMS/location data outside the task. See SECURITY.md.
 


### PR DESCRIPTION
## Auto-fix from audit 2026-08-03

**Issue:** AGENTS.md line 11 still referenced `pyproject version 0.3.0` after the v0.4.0 release (commit 4feeb1b).

**Fix:** Updated version string to `0.4.0`.

**Tests:** ✅ Gradle `testDebugUnitTest` — BUILD SUCCESSFUL, ✅ Python `pytest` — 131 passed.

**Severity:** Low / cosmetic.