### PR TITLE
fix(plugin): align manifest with v0.4.0 release

### DIFF
--- a/hermes-android-plugin/__init__.py
+++ b/hermes-android-plugin/__init__.py
@@ -1,6 +1,6 @@
 """
-hermes-android plugin — registers 14 android_* tools into hermes-agent via the
-v0.3.0 plugin system.
+hermes-android plugin — registers 38 android_* tools into hermes-agent via the
+v0.4.0 plugin system.
 
 Drop this folder into ~/.hermes/plugins/hermes-android and restart hermes.
 """

--- a/hermes-android-plugin/plugin.yaml
+++ b/hermes-android-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-android
-version: 0.3.0
+version: 0.4.0
 description: "Remote Android device control — read screen, tap, type, open apps, take screenshots via the Hermes Bridge companion app"
 author: raulvidis
 requires_env: []

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_plugin_manifest_version_matches_distribution_version():
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    manifest = yaml.safe_load(
+        (ROOT / "hermes-android-plugin" / "plugin.yaml").read_text(encoding="utf-8")
+    )
+
+    assert manifest["version"] == project["project"]["version"]


### PR DESCRIPTION
## Summary

The upstream v0.4.0 release updated the Python package and Android app version, but the standalone Hermes plugin manifest/module still reported v0.3.0. This change aligns both plugin metadata surfaces with the already-published v0.4.0 release and adds a regression test that keeps them in sync with `pyproject.toml`.

## Changes

- set `hermes-android-plugin/plugin.yaml` to `0.4.0`
- set the standalone plugin module version to `0.4.0`
- add metadata consistency coverage

## Verification

- Python suite: `132 passed`
- PluginManager registration canary: 38 `android_*` tools
- `git diff --check`
- no Android relay or physical device control was started

This is a metadata consistency fix only; it does not change the Android app or relay behavior.
