### PR TITLE
fix(bridge): enforce relay reconnect cap and unhardcode version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## [Unreleased]
 
+### Fixed
+- relay reconnect: an unreachable server address retried forever. Each failed attempt fired `onFailure`, which cancelled the retry coroutine and started a new one with a fresh counter, so the 5-attempt cap was never reached and the UI stayed stuck on "Connecting…". Attempt count and exponential backoff now live in a `ReconnectPolicy` whose budget survives across callbacks. The budget is refilled only by a user-initiated Connect or by a session that stayed up ≥60s — reaching `onOpen` is not enough, so a relay that accepts the socket and immediately drops it (wrong pairing code) also stops instead of flapping forever. Callbacks from superseded sockets are ignored via a generation guard, `onClosed`/`onFailure` for one dead socket can no longer schedule two attempts, and the exhaustion path retires the socket so a late callback can't overwrite the "Tap Connect to retry" status
+- version string on the main view was hardcoded to `v0.2.0` in both portrait and landscape layouts; now `v0.4.0`
+
 ## [0.4.0] - 2026-08-03
 
 ### Security

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/ReconnectPolicy.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/ReconnectPolicy.kt
@@ -1,0 +1,64 @@
+package com.hermesandroid.bridge.client
+
+/**
+ * Attempt counter + exponential backoff for [RelayClient] reconnects.
+ *
+ * State lives here rather than in the reconnect coroutine on purpose: every
+ * failed connect fires another `onFailure`, which schedules another reconnect.
+ * A counter local to that coroutine restarts at zero each time, so an
+ * unreachable address never exhausts its retries and loops forever.
+ *
+ * The budget is only restored by [reset] (a user-initiated connect) or by
+ * [onSessionEnded] for a session that stayed up at least [stableSessionMs].
+ * Merely reaching `onOpen` is NOT enough: a relay that accepts the socket and
+ * immediately closes it (wrong pairing code, auth reject) would otherwise
+ * refill the budget on every attempt and flap forever.
+ *
+ * All state is guarded by this object's monitor — [RelayClient] touches it from
+ * OkHttp callback threads, the reconnect coroutine, and the main thread.
+ */
+class ReconnectPolicy(
+    private val maxRetries: Int = 5,
+    private val maxBackoffMs: Long = 30_000L,
+    private val baseBackoffMs: Long = 1_000L,
+    private val stableSessionMs: Long = 60_000L,
+) {
+
+    private var attemptCount: Int = 0
+
+    val attempts: Int
+        @Synchronized get() = attemptCount
+
+    /** True once [maxRetries] attempts have been handed out without a reset. */
+    val isExhausted: Boolean
+        @Synchronized get() = attemptCount >= maxRetries
+
+    val limit: Int
+        get() = maxRetries
+
+    /**
+     * Consume one attempt and return how long to wait before it.
+     * Caller must check [isExhausted] first.
+     */
+    @Synchronized
+    fun nextBackoffMs(): Long {
+        val exponent = attemptCount.coerceAtMost(30)
+        attemptCount++
+        val backoff = baseBackoffMs shl exponent
+        return if (backoff <= 0L) maxBackoffMs else backoff.coerceAtMost(maxBackoffMs)
+    }
+
+    /**
+     * Report that a connection that had opened is now gone, having lasted
+     * [durationMs]. Only a session that proved stable refills the budget.
+     */
+    @Synchronized
+    fun onSessionEnded(durationMs: Long) {
+        if (durationMs >= stableSessionMs) attemptCount = 0
+    }
+
+    @Synchronized
+    fun reset() {
+        attemptCount = 0
+    }
+}

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
@@ -37,6 +37,20 @@ object RelayClient {
     private var scope: CoroutineScope? = null
     private var reconnectJob: Job? = null
     private var prefs: SharedPreferences? = null
+    private val reconnectPolicy = ReconnectPolicy(maxRetries = MAX_RETRIES, maxBackoffMs = MAX_BACKOFF_MS)
+
+    /** True between scheduling a reconnect and that attempt firing. Guards against
+     *  onClosed + onFailure both scheduling for the same dead connection. */
+    @Volatile
+    private var reconnectPending: Boolean = false
+
+    /** Bumped per connect attempt; callbacks from superseded sockets are ignored. */
+    @Volatile
+    private var generation: Int = 0
+
+    /** `System.nanoTime()` at the last onOpen, or 0 when no session is open. */
+    @Volatile
+    private var sessionStartedNs: Long = 0L
 
     @Volatile
     var isConnected: Boolean = false
@@ -60,21 +74,32 @@ object RelayClient {
         prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     }
 
+    // Shares the monitor with scheduleReconnect/beginReconnectAttempt: these run
+    // on the main thread while callbacks schedule reconnects on OkHttp threads,
+    // and an interleaving there can strand reconnectPending set with no
+    // coroutine left to clear it, killing auto-reconnect for the process.
+    @Synchronized
     fun connect(serverUrl: String, pairingCode: String) {
         disconnect()
 
         this.serverUrl = serverUrl
         this.pairingCode = pairingCode
         shouldReconnect = true
+        reconnectPolicy.reset()
 
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         doConnect(serverUrl, pairingCode)
     }
 
+    @Synchronized
     fun disconnect() {
         shouldReconnect = false
         reconnectJob?.cancel()
         reconnectJob = null
+        reconnectPending = false
+        reconnectPolicy.reset()
+        sessionStartedNs = 0L
+        generation++
         webSocket?.close(1000, "Client disconnecting")
         webSocket = null
         scope?.cancel()
@@ -95,6 +120,7 @@ object RelayClient {
     }
 
     private fun doConnect(serverUrl: String, pairingCode: String) {
+        val myGeneration = ++generation
         val wsUrl = buildWsUrl(serverUrl)
         Log.i(TAG, "Connecting to $wsUrl")
         notifyStatus(false, "Connecting to $wsUrl ...")
@@ -109,8 +135,16 @@ object RelayClient {
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
 
             override fun onOpen(webSocket: WebSocket, response: Response) {
+                if (myGeneration != generation) {
+                    webSocket.cancel()
+                    return
+                }
                 Log.i(TAG, "WebSocket connected to ${buildWsUrl(serverUrl)}")
                 isConnected = true
+                // NOT a policy reset: the budget is only refilled once this
+                // session proves stable (see endSession), so a relay that
+                // accepts and instantly drops us can't retry forever.
+                sessionStartedNs = System.nanoTime()
                 try {
                     BridgeAccessibilityService.instance?.startForeground()
                 } catch (e: SecurityException) {
@@ -131,57 +165,108 @@ object RelayClient {
             }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                if (myGeneration != generation) return
                 Log.i(TAG, "WebSocket closed: $code $reason")
                 isConnected = false
+                endSession()
                 notifyStatus(false, "Closed: code=$code $reason")
                 scheduleReconnect()
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                if (myGeneration != generation) return
                 val httpCode = response?.code ?: 0
                 val errorDetail = "Error: ${t.javaClass.simpleName}: ${t.message} (HTTP $httpCode)"
                 Log.e(TAG, "WebSocket failure: $errorDetail", t)
                 isConnected = false
+                endSession()
                 notifyStatus(false, errorDetail)
                 scheduleReconnect()
             }
         })
     }
 
+    // Invoked from OkHttp callback threads; the policy and the pending flag are
+    // read-modify-written together, so serialize the whole decision.
+    @Synchronized
     private fun scheduleReconnect() {
         if (!shouldReconnect) return
         val url = serverUrl ?: return
         val code = pairingCode ?: return
+        // Resolve the scope BEFORE burning budget or raising reconnectPending:
+        // a late callback after disconnect() finds a null scope, and committing
+        // that state with no coroutine to clear it would stall reconnects for good.
+        val activeScope = scope ?: return
 
-        reconnectJob?.cancel()
-        reconnectJob = scope?.launch {
-            var backoff = 1000L
-            var retries = 0
-            while (shouldReconnect && !isConnected && retries < MAX_RETRIES) {
-                retries++
-                Log.i(TAG, "Reconnecting in ${backoff}ms... (attempt $retries/$MAX_RETRIES)")
-                notifyStatus(false, "Reconnecting in ${backoff / 1000}s... (attempt $retries/$MAX_RETRIES)")
-                delay(backoff)
-                if (shouldReconnect && !isConnected) {
-                    // Cancel the previous WebSocket before opening a new one,
-                    // otherwise its listener stays active and can fire
-                    // out-of-order callbacks (onOpen/onFailure) that set
-                    // isConnected or push duplicate status notifications.
-                    webSocket?.cancel()
-                    doConnect(url, code)
-                    delay(3000)
-                    if (!isConnected) {
-                        backoff = (backoff * 2).coerceAtMost(MAX_BACKOFF_MS)
-                    } else {
-                        break
-                    }
-                }
-            }
-            if (!isConnected && retries >= MAX_RETRIES) {
-                notifyStatus(false, "Failed to connect after $MAX_RETRIES attempts. Tap Connect to retry.")
-                shouldReconnect = false
-            }
+        // onClosed and onFailure can both fire for one dead socket; only one of
+        // them should turn into an attempt. This must come BEFORE the exhausted
+        // check: otherwise the second callback sees the budget the first one
+        // just spent and declares failure while that final attempt is still
+        // waiting out its backoff, silently skipping the last retry.
+        if (reconnectPending) return
+
+        // Each failed attempt fires onFailure/onClosed, which lands back here.
+        // Bail out once the shared attempt budget is spent — otherwise an
+        // unreachable address reconnects forever.
+        if (reconnectPolicy.isExhausted) {
+            shouldReconnect = false
+            reconnectPending = false
+            // Retire the dead socket's listener too, otherwise a late callback
+            // from it overwrites the terminal status the user needs to see.
+            generation++
+            // Its onClosed/onFailure will now be ignored, so drop the session
+            // clock here — a stale start time would otherwise make the NEXT
+            // session look long enough to refill the retry budget.
+            sessionStartedNs = 0L
+            webSocket?.cancel()
+            webSocket = null
+            notifyStatus(false, "Failed to connect after ${reconnectPolicy.limit} attempts. Tap Connect to retry.")
+            return
         }
+
+        reconnectPending = true
+
+        val backoff = reconnectPolicy.nextBackoffMs()
+        val attempt = reconnectPolicy.attempts
+
+        reconnectJob = activeScope.launch {
+            Log.i(TAG, "Reconnecting in ${backoff}ms... (attempt $attempt/${reconnectPolicy.limit})")
+            notifyStatus(false, "Reconnecting in ${backoff / 1000}s... (attempt $attempt/${reconnectPolicy.limit})")
+            delay(backoff)
+            beginReconnectAttempt(url, code)
+        }
+    }
+
+    /**
+     * Clearing [reconnectPending] and starting the attempt must happen as one
+     * step under the same monitor as [scheduleReconnect]; clearing it earlier
+     * lets a callback slip through and launch a second reconnect coroutine.
+     */
+    @Synchronized
+    private fun beginReconnectAttempt(url: String, code: String) {
+        reconnectPending = false
+        if (!shouldReconnect || isConnected) return
+        // Supersede the old listener BEFORE cancelling its socket: cancel()
+        // drives that listener's onFailure, and if it still matched the current
+        // generation it would re-enter scheduleReconnect and burn an attempt on
+        // our own teardown.
+        generation++
+        // Retired listener => no endSession() for it; drop the clock so the
+        // next session is measured from its own start, not this one's.
+        sessionStartedNs = 0L
+        // Cancel the previous WebSocket before opening a new one, otherwise its
+        // listener stays active and can fire out-of-order callbacks
+        // (onOpen/onFailure) that set isConnected or push duplicate statuses.
+        webSocket?.cancel()
+        doConnect(url, code)
+    }
+
+    /** A session that had opened is over — refill the budget only if it was stable. */
+    private fun endSession() {
+        val startedNs = sessionStartedNs
+        if (startedNs == 0L) return
+        sessionStartedNs = 0L
+        reconnectPolicy.onSessionEnded((System.nanoTime() - startedNs) / 1_000_000L)
     }
 
     private fun buildWsUrl(serverUrl: String): String {

--- a/hermes-android-bridge/app/src/main/res/layout-land/activity_main.xml
+++ b/hermes-android-bridge/app/src/main/res/layout-land/activity_main.xml
@@ -33,7 +33,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="v0.2.0"
+            android:text="v0.4.0"
             android:textSize="12sp"
             android:textColor="#666666"
             android:fontFamily="monospace" />

--- a/hermes-android-bridge/app/src/main/res/layout/activity_main.xml
+++ b/hermes-android-bridge/app/src/main/res/layout/activity_main.xml
@@ -33,7 +33,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="v0.2.0"
+            android:text="v0.4.0"
             android:textSize="12sp"
             android:textColor="#666666"
             android:fontFamily="monospace" />

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/client/ReconnectPolicyTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/client/ReconnectPolicyTest.kt
@@ -1,0 +1,123 @@
+package com.hermesandroid.bridge.client
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReconnectPolicyTest {
+
+    @Test
+    fun `attempts are exhausted after maxRetries`() {
+        val policy = ReconnectPolicy(maxRetries = 5)
+
+        repeat(5) {
+            assertFalse("attempt ${it + 1} should be allowed", policy.isExhausted)
+            policy.nextBackoffMs()
+        }
+        assertTrue("budget should be spent after 5 attempts", policy.isExhausted)
+    }
+
+    /**
+     * Regression: a bad server address used to retry forever. Every failed
+     * attempt fires another failure callback, which previously restarted the
+     * retry loop with a fresh counter, so the cap was never reached.
+     */
+    @Test
+    fun `repeated failure callbacks never revive an exhausted budget`() {
+        val policy = ReconnectPolicy(maxRetries = 5)
+
+        var attemptsMade = 0
+        // Simulate 100 failure callbacks against an unreachable address.
+        repeat(100) {
+            if (!policy.isExhausted) {
+                policy.nextBackoffMs()
+                attemptsMade++
+            }
+        }
+
+        assertEquals("must stop after the retry cap", 5, attemptsMade)
+        assertTrue(policy.isExhausted)
+    }
+
+    @Test
+    fun `backoff grows exponentially and clamps to the max`() {
+        val policy = ReconnectPolicy(maxRetries = 10, maxBackoffMs = 30_000L, baseBackoffMs = 1_000L)
+
+        assertEquals(1_000L, policy.nextBackoffMs())
+        assertEquals(2_000L, policy.nextBackoffMs())
+        assertEquals(4_000L, policy.nextBackoffMs())
+        assertEquals(8_000L, policy.nextBackoffMs())
+        assertEquals(16_000L, policy.nextBackoffMs())
+        assertEquals("clamped", 30_000L, policy.nextBackoffMs())
+        assertEquals("stays clamped", 30_000L, policy.nextBackoffMs())
+    }
+
+    @Test
+    fun `reset restores the full budget after a successful connect`() {
+        val policy = ReconnectPolicy(maxRetries = 3)
+
+        repeat(3) { policy.nextBackoffMs() }
+        assertTrue(policy.isExhausted)
+
+        policy.reset()
+
+        assertFalse("a successful connect should restore retries", policy.isExhausted)
+        assertEquals(0, policy.attempts)
+        assertEquals("backoff restarts from the base delay", 1_000L, policy.nextBackoffMs())
+    }
+
+    /**
+     * Regression: resetting on every `onOpen` reopened the infinite loop for a
+     * relay that accepts the socket and immediately drops it (wrong pairing
+     * code). Only a session that stayed up refills the budget.
+     */
+    @Test
+    fun `a flapping server cannot refill the budget forever`() {
+        val policy = ReconnectPolicy(maxRetries = 5, stableSessionMs = 60_000L)
+
+        var attemptsMade = 0
+        repeat(100) {
+            if (!policy.isExhausted) {
+                policy.nextBackoffMs()
+                attemptsMade++
+                // Connection opens, then dies 250ms later — never stable.
+                policy.onSessionEnded(250L)
+            }
+        }
+
+        assertEquals("short-lived sessions must not refill retries", 5, attemptsMade)
+        assertTrue(policy.isExhausted)
+    }
+
+    @Test
+    fun `a stable session refills the budget`() {
+        val policy = ReconnectPolicy(maxRetries = 5, stableSessionMs = 60_000L)
+
+        repeat(4) { policy.nextBackoffMs() }
+        policy.onSessionEnded(90_000L) // an hour-long session dropping is not a failure streak
+
+        assertEquals(0, policy.attempts)
+        assertFalse(policy.isExhausted)
+    }
+
+    @Test
+    fun `session exactly at the stability threshold counts as stable`() {
+        val policy = ReconnectPolicy(maxRetries = 5, stableSessionMs = 60_000L)
+
+        repeat(3) { policy.nextBackoffMs() }
+        policy.onSessionEnded(60_000L)
+
+        assertEquals(0, policy.attempts)
+    }
+
+    @Test
+    fun `backoff never overflows into a negative delay`() {
+        val policy = ReconnectPolicy(maxRetries = 1_000, maxBackoffMs = 30_000L)
+
+        repeat(200) {
+            val backoff = policy.nextBackoffMs()
+            assertTrue("backoff must stay positive, got $backoff", backoff in 1L..30_000L)
+        }
+    }
+}


### PR DESCRIPTION
Picks up two fixes started by a local model whose push failed. The version-string change survived in the working tree; the reconnect fix did not (nothing in the tree, stash, or dangling objects), so it is reimplemented here.

## 1. Connecting → retry loop never terminates

`MAX_RETRIES = 5` has existed since the initial commit but was never reachable. The counter lived inside the reconnect coroutine:

```kotlin
reconnectJob?.cancel()
reconnectJob = scope?.launch {
    var retries = 0                       // reset on every scheduleReconnect()
    while (... && retries < MAX_RETRIES) { ... }
}
```

Each failed attempt fires `onFailure` → `scheduleReconnect()`, which cancels the in-flight coroutine and starts a new one with `retries = 0`. A bad address retries forever and the UI stays on "Connecting…".

The counter and backoff now live in `ReconnectPolicy`, held by `RelayClient`, so the budget survives across callbacks.

**Budget refill is deliberately not `onOpen`.** Resetting when the socket merely opens reopens the same bug for a relay that accepts and immediately closes (wrong pairing code) — it would flap at 1s backoff forever. The budget refills only on a user-initiated Connect, or when a session stayed up ≥60s.

## 2. Hardcoded version string

`v0.2.0` → `v0.4.0` in the portrait and landscape `activity_main.xml`.

## Review findings folded in

Six `$autoreview` passes; each of these was a real reachable defect, not hardening:

- `webSocket.cancel()` ran before `doConnect` bumped the generation, so our own teardown passed the guard and burned an attempt — budget could be spent in 2–3 real attempts.
- Resetting on `onOpen` left the flapping-server case looping forever (above).
- `reconnectPending` was cleared in a `finally` outside the monitor, allowing two live reconnect coroutines.
- Budget/pending state was committed before `scope` was resolved; a late callback after `disconnect()` stranded `reconnectPending = true`, permanently killing auto-reconnect.
- A socket retired via `generation++` never cleared `sessionStartedNs`, so the next session was measured from the older one's start and could refill the budget it shouldn't.
- `connect()`/`disconnect()` mutated monitor-protected state without the monitor.
- The exhaustion check preceded the duplicate-callback guard, so the second of `onClosed`/`onFailure` declared failure while the final attempt was still in backoff — silently skipping the last retry.

## Tests

`ReconnectPolicyTest` — 8 cases, including the two regressions (repeated failure callbacks never revive an exhausted budget; a flapping server cannot refill it) plus backoff growth, clamping, overflow safety, and reset semantics.

Full suite: 64 pass, 0 fail. `assembleDebug` builds.

## Worth a decision before merge

The cap is now genuinely enforced at 5 attempts (~31s), matching the original code's intent. That also means a transient network drop within the first 60s of a session permanently stops the bridge until someone taps Connect. For a headless remote-control bridge you may prefer indefinite retry at max backoff once a session has succeeded, with the hard cap only for never-connected addresses. I kept the original semantics rather than widening scope — happy to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
