### PR TITLE
feat: Microphone support Phase 1 (Ambient Sound Recording)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## [Unreleased]
 
+### Added
+- four microphone tools (`android_mic_record`, `android_mic_stop`, `android_mic_status`, `android_mic_fetch`) with relay-routed binary WAV streaming and `MEDIA:` delivery
+- recorder state reporting and atomic `.part` → `.wav` finalization so interrupted recordings are never advertised as complete
+- keep-last-10 retention for completed WAV recordings
+
+### Security
+- remove device-specific connection details and legacy SCP instructions from microphone tooling
+- stop logging notification content and pairing-token prefixes, including in debug builds
+
+### Fixed
+- use one canonical microphone directory for recording, status, and download
+- use the on-device-tested `VOICE_RECOGNITION` source with saturating 2.5x PCM gain and stop the recorder service after a STOP command
+- register microphone routes, schemas, and handlers in both the standalone toolset and installable plugin
+- replace deprecated aiohttp bare route handlers and add end-to-end binary-stream regression coverage
+
 ## [0.4.1] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This repo contains **two components**:
 | Component | Path | Language | Purpose |
 |-----------|------|----------|---------|
 | **Android bridge app** | `hermes-android-bridge/` | Kotlin | Runs on the phone. Connects to server via WebSocket, executes commands via AccessibilityService |
-| **Python toolset** | `tools/`, `tests/` | Python | Runs on the server. 38 `android_*` tools + WebSocket relay. Also lives in [hermes-agent](https://github.com/NousResearch/hermes-agent) as the production copy |
+| **Python toolset** | `tools/`, `tests/` | Python | Runs on the server. 42 `android_*` tools + WebSocket relay. Also lives in [hermes-agent](https://github.com/NousResearch/hermes-agent) as the production copy |
 
 > **Note:** The Python code exists here for standalone development and testing (`pip install -e .`, `pytest`). The production copy is in the hermes-agent repo. The Android app does not use or depend on the Python files.
 
-## Install as hermes-agent plugin (v0.3.0+)
+## Install as hermes-agent plugin (hermes-agent v0.3.0+)
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/raulvidis/hermes-android/main/install.sh | bash
@@ -34,7 +34,7 @@ mkdir -p ~/.hermes/plugins
 cp -r hermes-android-plugin ~/.hermes/plugins/hermes-android
 ```
 
-Restart hermes — run `/plugins` to verify. Should show: `✓ hermes-android v0.3.0 (38 tools)`
+Restart hermes — run `/plugins` to verify. Should show: `✓ hermes-android v0.4.1 (42 tools)`
 
 ## Quick Start
 
@@ -62,6 +62,7 @@ adb install app/build/outputs/apk/debug/hermes-android-*.apk
 - Tap **Enable Status Overlay** → grant permission
 - Tap **Grant Screen Recording** → approve the system dialog (needed for `android_screen_record`)
 - Grant additional runtime permissions in **Settings > Apps > Hermes Bridge > Permissions**:
+  - **Microphone** — for `android_mic_record`
   - **Location** — for `android_location`
   - **Contacts** — for `android_search_contacts`
   - **SMS** — for `android_send_sms`
@@ -117,7 +118,7 @@ The car head unit needs network access to reach the relay server:
 All other tools (tap, swipe, type, screenshot, read screen, open apps, etc.) work normally.
 
 
-## Tools (38)
+## Tools (42)
 
 | Tool | Description |
 |------|-------------|
@@ -155,9 +156,17 @@ All other tools (tap, swipe, type, screenshot, read screen, open apps, etc.) wor
 | `android_events` | Read recent accessibility events |
 | `android_event_stream` | Stream accessibility events in real-time |
 | `android_screen_record` | Record screen video for a duration |
+| `android_mic_record` | Start a 16 kHz mono WAV recording (30-minute safety cap) |
+| `android_mic_stop` | Stop and finalize the active recording |
+| `android_mic_status` | Read recorder state and latest-file metadata |
+| `android_mic_fetch` | Stream a completed WAV to a local `MEDIA:` file |
 | `android_read_widgets` | Read home screen widgets |
 | `android_speak` | Text-to-speech output |
 | `android_speak_stop` | Stop text-to-speech |
+
+Microphone recordings use the speech-oriented Android audio source with bounded
+PCM gain. The bridge retains the 10 newest completed WAV files and removes older
+ones after successful finalization.
 
 ## Permissions
 
@@ -166,6 +175,7 @@ All other tools (tap, swipe, type, screenshot, read screen, open apps, etc.) wor
 | Accessibility Service | App button → Settings > Accessibility | All tools (core requirement) |
 | System Alert Window (Overlay) | App button → Settings > Draw over apps | Status overlay display |
 | Screen Recording (MediaProjection) | App button → approve system dialog | `android_screen_record` |
+| Microphone | Settings > Apps > Permissions > Microphone | `android_mic_record` |
 | Location | Settings > Apps > Permissions > Location | `android_location` |
 | Read Contacts | Settings > Apps > Permissions > Contacts | `android_search_contacts` |
 | Send SMS | Settings > Apps > Permissions > SMS | `android_send_sms` |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,8 @@ hermes-android gives a remote AI agent full control of an Android device via Acc
 - The phone sends the pairing code as an `Authorization: Bearer` header on the
   WebSocket handshake — never in the URL, so it does not land in reverse-proxy
   access logs
-- The relay still accepts a legacy `?token=` query parameter from older APKs;
-  if you run a reverse proxy, configure it not to log query strings on `/ws`
-  until all devices are updated
+- Legacy `?token=` query authentication is rejected so pairing codes cannot land
+  in reverse-proxy access logs
 
 ### Connection Architecture
 - The phone connects **out** to the server (NAT-friendly)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 ---
-summary: "Kotlin bridge ↔ Python toolset ↔ WebSocket relay; the 36 android_* tools and how a command flows end-to-end."
+summary: "Kotlin bridge ↔ Python toolset ↔ WebSocket relay; the 42 android_* tools and how a command flows end-to-end."
 read_when:
   - "Changing the relay, bridge app, or tool wiring"
   - "Tracing how an android_* tool call reaches the phone"
@@ -30,10 +30,10 @@ The Python code is standalone here for dev/test (`pip install -e .`, `pytest`); 
 ## Data flow (relay mode)
 
 1. `android_setup(pairing_code)` starts the relay + configures auth.
-2. Phone connects: `ws://server:8766/ws?token=<pairing_code>`.
+2. Phone connects to `/ws` with `Authorization: Bearer <pairing_code>`.
 3. Agent calls an `android_*` tool → HTTP request to `localhost:8766`.
 4. Relay wraps it as a JSON command, sends over WebSocket to the phone.
-5. Phone executes via AccessibilityService, returns JSON over WebSocket.
+5. Phone executes the command and returns JSON over WebSocket; completed microphone WAVs use bounded binary frames with length and SHA-256 verification. The bridge keeps the 10 newest completed recordings.
 6. Relay returns the phone's response as the HTTP response.
 
 ### Command envelope
@@ -66,13 +66,13 @@ Required permissions: `ACCESSIBILITY_SERVICE`, `SYSTEM_ALERT_WINDOW`, `INTERNET`
 
 aiohttp server in a background daemon thread, started by `android_setup()`.
 
-- `/ws` (WebSocket) — phone connects with `?token=<pairing_code>`.
+- `/ws` (WebSocket) — phone connects with a Bearer authorization header.
 - `/ping`, `/screen`, `/screenshot`, `/apps`, `/current_app` (GET); `/tap`, `/tap_text`, `/type`, `/swipe`, `/open_app`, `/press_key`, `/scroll`, `/wait` (POST).
 - Auth: pairing code case-sensitive (exact compare, see #43). 5 failed attempts / 60s → IP blocked 5 min. Only one phone connected at a time.
 
 ## Tools
 
-36 `android_*` tools span: connectivity (`ping`, `setup`), screen reading (`read_screen`, `screenshot`, `current_app`, `find_nodes`, `describe_node`, `screen_hash`, `diff_screen`), apps (`open_app`, `get_apps`), input (`tap`, `tap_text`, `type`, `long_press`, `drag`, `pinch`), gestures (`swipe`, `scroll`), keys (`press_key`), waiting (`wait`), device (`location`, `search_contacts`, `send_sms`, `call`, `media`, `send_intent`, `broadcast`, `clipboard_read`, `clipboard_write`), events (`notifications`, `events`, `event_stream`), capture (`screen_record`, `read_widgets`), voice (`speak`, `speak_stop`). See README for the full table.
+42 `android_*` tools span: connectivity (`ping`, `setup`), screen reading (`read_screen`, `screenshot`, `current_app`, `find_nodes`, `describe_node`, `screen_hash`, `diff_screen`), apps (`open_app`, `get_apps`), input (`tap`, `tap_text`, `type`, `long_press`, `drag`, `pinch`), gestures (`swipe`, `scroll`), keys (`press_key`), waiting (`wait`), device (`location`, `search_contacts`, `send_sms`, `call`, `media`, `send_intent`, `broadcast`, `clipboard_read`, `clipboard_write`), events (`notifications`, `events`, `event_stream`), capture (`screen_record`, `read_widgets`), microphone (`mic_record`, `mic_stop`, `mic_status`, `mic_fetch`), and voice (`speak`, `speak_stop`). See README for the full table.
 
 ## Integration paths
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Each doc carries YAML frontmatter (`summary` + `read_when`). Read the one whose 
 
 | Doc | Summary | Read when |
 |-----|---------|-----------|
-| [architecture.md](architecture.md) | Kotlin bridge ↔ Python toolset ↔ WebSocket relay; 36 `android_*` tools. | Changing relay/bridge/tool wiring; understanding data flow |
+| [architecture.md](architecture.md) | Kotlin bridge ↔ Python toolset ↔ WebSocket relay; 42 `android_*` tools. | Changing relay/bridge/tool wiring; understanding data flow |
 | [quickstart.md](quickstart.md) | Get a phone controlled in ~5 minutes. | First-time setup; demoing the system |
 | [install.md](install.md) | Full install of plugin + bridge APK. | Installing from scratch; debugging install |
 | [configuration.md](configuration.md) | All env vars and config options. | Changing ports, URLs, tokens, timeouts |

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ What it does:
 3. Installs `aiohttp` if missing (`pip`/`pip3`).
 4. Cleans up the temp dir.
 
-Then restart hermes-gateway and run `/plugins` to verify — should show `✓ hermes-android v0.3.0 (38 tools)`.
+Then restart hermes-gateway and run `/plugins` to verify — should show `✓ hermes-android v0.4.1 (42 tools)`.
 
 Manual alternative:
 ```bash

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -24,17 +24,25 @@ Automated: `pytest tests/` (Python toolset) and `cd hermes-android-bridge && ./g
 8. `android_screenshot()` → returns `MEDIA:` path; image correct.
 9. `android_wait(text=...)` resolves after navigation.
 
+## Microphone (real device)
+
+10. Grant the Hermes Bridge microphone permission, connect the relay, then press Home so the app UI is backgrounded.
+11. From the agent host, call `android_mic_record(duration=3)`; it must return `starting` and show the foreground-service notification despite the app UI being backgrounded.
+12. Wait for `android_mic_status()` to report `ready`, then call `android_mic_fetch()`; verify the returned `MEDIA:` file is a playable 16 kHz mono WAV with audible speech.
+13. Start with `android_mic_record(duration=0)`, call `android_mic_stop()`, wait for `ready`, then verify `adb shell dumpsys activity services com.hermesandroid.bridge` no longer lists `MicrophoneRecorderService`.
+14. Create more than 10 short recordings; `android_mic_status()` must report at most 10 completed WAVs and the newest recording must remain downloadable.
+
 ## Sensitive paths (verify PII stripping)
 
-10. `android_send_sms` / `android_call` → success response contains NO phone number/recipient.
-11. `android_location` → guarded if permission absent (#49).
-12. `android_clipboard_write` response strips content per convention (#35).
+15. `android_send_sms` / `android_call` → success response contains NO phone number/recipient.
+16. `android_location` → guarded if permission absent (#49).
+17. `android_clipboard_write` response strips content per convention (#35).
 
 ## Auth / rate limiting
 
-13. 5 wrong pairing codes within 60s → IP blocked 5 min, HTTP 429 (#51).
-14. Correct code → connects.
+18. 5 wrong pairing codes within 60s → IP blocked 5 min, HTTP 429 (#51).
+19. Correct code → connects.
 
 ## AAOS (if applicable)
 
-15. SMS/calls/contacts return graceful errors; tap/type/screenshot work.
+20. SMS/calls/contacts return graceful errors; tap/type/screenshot work.

--- a/hermes-android-bridge/app/src/main/AndroidManifest.xml
+++ b/hermes-android-bridge/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <!-- Microphone for ambient sound / voice capture (Phase 1 Ohren) -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <!-- Screenshots via MediaProjection (Phase 2 enhancement) -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <!-- Query all installed apps (Android 11+) -->
@@ -65,6 +68,12 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+
+        <!-- Microphone recorder service (Phase 1 Ohren) -->
+        <service
+            android:name=".audio.MicrophoneRecorderService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
 
     </application>
 </manifest>

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/BridgeApplication.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/BridgeApplication.kt
@@ -8,8 +8,14 @@ import com.hermesandroid.bridge.power.WakeLockManager
 import com.hermesandroid.bridge.server.BridgeServer
 
 class BridgeApplication : Application() {
+    companion object {
+        lateinit var instance: BridgeApplication
+            private set
+    }
+
     override fun onCreate() {
         super.onCreate()
+        instance = this
         PairingManager.init(applicationContext)
         DeviceCapabilities.init(applicationContext)
         WakeLockManager.init(applicationContext)

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecorderService.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecorderService.kt
@@ -1,0 +1,292 @@
+package com.hermesandroid.bridge.audio
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.os.IBinder
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Records PCM16 microphone audio and publishes completed WAV files atomically. */
+class MicrophoneRecorderService : Service() {
+
+    companion object {
+        internal const val MAX_DURATION_SECONDS = 30 * 60
+        private const val CHANNEL_ID = "hermes_bridge_mic"
+        private const val NOTIFICATION_ID = 1001
+        private const val SAMPLE_RATE = 16_000
+        private const val ACTION_START = "start"
+        private const val ACTION_STOP = "stop"
+        private const val EXTRA_DURATION = "duration"
+
+        fun start(context: Context, durationSec: Int = 0) {
+            require(durationSec in 0..MAX_DURATION_SECONDS) {
+                "duration must be between 0 and $MAX_DURATION_SECONDS seconds"
+            }
+            startServiceCommand(context, ACTION_START, durationSec)
+        }
+
+        fun stop(context: Context) {
+            startServiceCommand(context, ACTION_STOP, 0)
+        }
+
+        private fun startServiceCommand(context: Context, actionName: String, durationSec: Int) {
+            val intent = Intent(context, MicrophoneRecorderService::class.java).apply {
+                action = actionName
+                putExtra(EXTRA_DURATION, durationSec)
+            }
+            context.startForegroundService(intent)
+        }
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val isRecording = AtomicBoolean(false)
+    private val stopRequested = AtomicBoolean(false)
+
+    @Volatile
+    private var recorder: AudioRecord? = null
+    private var recordingJob: Job? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification("Preparing microphone…"))
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action ?: ACTION_START) {
+            ACTION_STOP -> requestStop()
+            else -> startRecording(intent?.getIntExtra(EXTRA_DURATION, 0) ?: 0)
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun startRecording(durationSec: Int) {
+        if (!isRecording.compareAndSet(false, true)) return
+        stopRequested.set(false)
+
+        if (checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+            failBeforeRecording("Microphone permission is not granted")
+            return
+        }
+        if (durationSec !in 0..MAX_DURATION_SECONDS) {
+            failBeforeRecording("Requested duration is outside the supported range")
+            return
+        }
+
+        val pending = runCatching { MicrophoneRecordingFiles.createPending(this) }
+            .getOrElse { error ->
+                failBeforeRecording(safeError("Could not prepare recording", error))
+                return
+            }
+        MicrophoneRecordingState.markStarting(pending.completedFile.name)
+
+        val minimumBuffer = AudioRecord.getMinBufferSize(
+            SAMPLE_RATE,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+        )
+        if (minimumBuffer <= 0) {
+            failBeforeRecording("No supported microphone buffer is available")
+            return
+        }
+
+        val audioRecord = runCatching {
+            AudioRecord(
+                // VOICE_RECOGNITION enables the platform's speech-oriented
+                // preprocessing. On-device tests on a Pixel 6 produced usable
+                // levels here where the raw MIC source was effectively silent.
+                MediaRecorder.AudioSource.VOICE_RECOGNITION,
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                minimumBuffer * 4,
+            )
+        }.getOrElse { error ->
+            failBeforeRecording(safeError("Could not initialize microphone", error))
+            return
+        }
+        if (audioRecord.state != AudioRecord.STATE_INITIALIZED) {
+            audioRecord.release()
+            failBeforeRecording("Microphone is not available")
+            return
+        }
+
+        recorder = audioRecord
+        recordingJob = scope.launch {
+            var writer: WavFileWriter? = null
+            try {
+                writer = WavFileWriter(pending, SAMPLE_RATE)
+                audioRecord.startRecording()
+                if (audioRecord.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+                    throw IllegalStateException("Microphone did not enter recording state")
+                }
+
+                MicrophoneRecordingState.markRecording()
+                updateNotification("Recording…")
+
+                val samples = ShortArray((minimumBuffer / 2).coerceAtLeast(1024))
+                // A missing stop command must not fill a permanently powered
+                // device. duration=0 still means "until stopped", but only up
+                // to the same documented Phase-1 safety ceiling.
+                val effectiveDuration = if (durationSec == 0) MAX_DURATION_SECONDS else durationSec
+                val sampleLimit = SAMPLE_RATE.toLong() * effectiveDuration.toLong()
+
+                while (isActive && isRecording.get() && writer.totalSamples < sampleLimit) {
+                    val requested = minOf(samples.size.toLong(), sampleLimit - writer.totalSamples).toInt()
+                    val read = audioRecord.read(
+                        samples,
+                        0,
+                        requested,
+                        AudioRecord.READ_BLOCKING,
+                    )
+                    if (read > 0) {
+                        PcmSampleProcessor.applyRecordingGain(samples, read)
+                        writer.write(samples, read)
+                        MicrophoneRecordingState.markRecording(writer.totalSamples * 2L)
+                    } else if (!stopRequested.get()) {
+                        throw IOException("AudioRecord read failed with code $read")
+                    }
+                }
+
+                MicrophoneRecordingState.markFinalizing(writer.totalSamples * 2L)
+                updateNotification("Finalizing recording…")
+                safelyStop(audioRecord)
+                val completed = writer.finish()
+                MicrophoneRecordingFiles.enforceRetention(this@MicrophoneRecorderService)
+                MicrophoneRecordingState.markReady(completed, writer.totalSamples * 2L)
+                updateNotification("Recording ready")
+            } catch (cancelled: CancellationException) {
+                finalizeInterruptedWriter(writer)
+                throw cancelled
+            } catch (error: Throwable) {
+                val recovered = finalizeInterruptedWriter(writer)
+                val message = safeError("Microphone recording failed", error)
+                MicrophoneRecordingState.markError(message)
+                updateNotification(if (recovered) "Recording stopped with an error" else message)
+            } finally {
+                safelyStop(audioRecord)
+                runCatching { audioRecord.release() }
+                if (recorder === audioRecord) recorder = null
+                writer?.close()
+                isRecording.set(false)
+                stopRequested.set(false)
+                recordingJob = null
+                stopForegroundCompat()
+                // A STOP command has a newer startId than the original START.
+                // stopSelfResult(startId) would therefore leave this service
+                // alive after finalization.
+                stopSelf()
+            }
+        }
+    }
+
+    private fun finalizeInterruptedWriter(writer: WavFileWriter?): Boolean {
+        if (writer == null || writer.totalSamples == 0L) {
+            writer?.abort()
+            return false
+        }
+        return runCatching {
+            MicrophoneRecordingState.markFinalizing(writer.totalSamples * 2L)
+            val completed = writer.finish()
+            MicrophoneRecordingFiles.enforceRetention(this)
+            MicrophoneRecordingState.markReady(completed, writer.totalSamples * 2L)
+        }.isSuccess
+    }
+
+    private fun requestStop() {
+        if (!isRecording.get()) {
+            stopForegroundCompat()
+            stopSelf()
+            return
+        }
+        stopRequested.set(true)
+        isRecording.set(false)
+        MicrophoneRecordingState.markFinalizing(
+            MicrophoneRecordingState.snapshot().bytesWritten,
+        )
+        safelyStop(recorder)
+    }
+
+    private fun failBeforeRecording(message: String) {
+        isRecording.set(false)
+        stopRequested.set(false)
+        MicrophoneRecordingState.markError(message)
+        updateNotification(message)
+        stopForegroundCompat()
+        stopSelf()
+    }
+
+    private fun safelyStop(audioRecord: AudioRecord?) {
+        if (audioRecord == null) return
+        runCatching {
+            if (audioRecord.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
+                audioRecord.stop()
+            }
+        }
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Hermes Bridge microphone",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Visible indicator while Hermes Bridge records microphone audio"
+        }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(text: String): Notification {
+        return Notification.Builder(this, CHANNEL_ID)
+            .setContentTitle("Hermes Bridge microphone")
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .setOngoing(true)
+            .build()
+    }
+
+    private fun updateNotification(text: String) {
+        // Updating the existing foreground-service notification this way does
+        // not require the Android 13 POST_NOTIFICATIONS runtime permission.
+        startForeground(NOTIFICATION_ID, buildNotification(text))
+    }
+
+    private fun stopForegroundCompat() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+    }
+
+    private fun safeError(prefix: String, error: Throwable): String =
+        "$prefix (${error.javaClass.simpleName})"
+
+    override fun onDestroy() {
+        stopRequested.set(true)
+        isRecording.set(false)
+        safelyStop(recorder)
+        recordingJob?.cancel()
+        if (recordingJob == null) {
+            runCatching { recorder?.release() }
+            recorder = null
+        }
+        scope.cancel()
+        super.onDestroy()
+    }
+}

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingFiles.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingFiles.kt
@@ -1,0 +1,92 @@
+package com.hermesandroid.bridge.audio
+
+import android.content.Context
+import android.os.Environment
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+internal data class PendingMicrophoneRecording(
+    val temporaryFile: File,
+    val completedFile: File,
+)
+
+/** Owns the one canonical location and naming policy for microphone recordings. */
+internal object MicrophoneRecordingFiles {
+    internal const val MAX_COMPLETED_RECORDINGS = 10
+    private const val DIRECTORY_NAME = "cradata_audio"
+    private val safeName = Regex("[A-Za-z0-9._-]+\\.wav")
+    private val safeIncompleteName = Regex("[A-Za-z0-9._-]+\\.wav\\.part")
+
+    fun directory(context: Context): File {
+        val parent = context.getExternalFilesDir(Environment.DIRECTORY_MUSIC) ?: context.filesDir
+        return File(parent, DIRECTORY_NAME).also { directory ->
+            if (!directory.exists() && !directory.mkdirs()) {
+                throw IllegalStateException("Could not create microphone recording directory")
+            }
+        }
+    }
+
+    fun createPending(context: Context, now: Date = Date()): PendingMicrophoneRecording {
+        val directory = directory(context)
+        directory.listFiles()
+            ?.filter { it.isFile && safeIncompleteName.matches(it.name) }
+            ?.forEach { it.delete() }
+
+        val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.ROOT).format(now)
+        var suffix = 0
+        var completed: File
+        var temporary: File
+        do {
+            val suffixText = if (suffix == 0) "" else "_$suffix"
+            completed = File(directory, "recording_${timestamp}${suffixText}.wav")
+            temporary = File(directory, "${completed.name}.part")
+            suffix += 1
+        } while (completed.exists() || temporary.exists())
+
+        return PendingMicrophoneRecording(
+            temporaryFile = temporary,
+            completedFile = completed,
+        )
+    }
+
+    fun listCompleted(context: Context): List<File> = listCompleted(directory(context))
+
+    fun latest(context: Context): File? = listCompleted(context).firstOrNull()
+
+    /** Keep storage bounded while never touching incomplete or unrelated files. */
+    fun enforceRetention(context: Context): Int =
+        enforceRetention(directory(context), MAX_COMPLETED_RECORDINGS)
+
+    internal fun enforceRetention(directory: File, keepLast: Int): Int {
+        require(keepLast >= 1) { "keepLast must be positive" }
+        return listCompleted(directory)
+            .drop(keepLast)
+            .count { file -> runCatching { file.delete() }.getOrDefault(false) }
+    }
+
+    /** Resolve only generated WAV basenames; paths and traversal sequences are rejected. */
+    fun resolve(context: Context, requestedName: String?): File? {
+        if (requestedName.isNullOrBlank()) return latest(context)
+        if (!safeName.matches(requestedName) || File(requestedName).name != requestedName) return null
+
+        val directory = directory(context).canonicalFile
+        val candidate = File(directory, requestedName).canonicalFile
+        return candidate.takeIf {
+            it.parentFile == directory && it.isFile && safeName.matches(it.name)
+        }
+    }
+
+    private fun listCompleted(directory: File): List<File> =
+        directory
+            .listFiles()
+            ?.asSequence()
+            ?.filter { it.isFile && safeName.matches(it.name) }
+            ?.sortedWith(
+                compareByDescending<File> { it.lastModified() }
+                    .thenByDescending { it.name },
+            )
+            ?.toList()
+            ?: emptyList()
+}

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingState.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingState.kt
@@ -1,0 +1,92 @@
+package com.hermesandroid.bridge.audio
+
+import java.io.File
+
+internal enum class MicrophoneRecordingPhase {
+    IDLE,
+    STARTING,
+    RECORDING,
+    FINALIZING,
+    READY,
+    ERROR,
+}
+
+internal data class MicrophoneRecordingSnapshot(
+    val phase: MicrophoneRecordingPhase = MicrophoneRecordingPhase.IDLE,
+    val activeFileName: String? = null,
+    val bytesWritten: Long = 0L,
+    val startedAtMs: Long? = null,
+    val error: String? = null,
+) {
+    val isActive: Boolean
+        get() = phase == MicrophoneRecordingPhase.STARTING ||
+            phase == MicrophoneRecordingPhase.RECORDING ||
+            phase == MicrophoneRecordingPhase.FINALIZING
+}
+
+internal object MicrophoneRecordingState {
+    @Volatile
+    private var current = MicrophoneRecordingSnapshot()
+
+    fun snapshot(): MicrophoneRecordingSnapshot = current
+
+    @Synchronized
+    fun tryReserveStart(): Boolean {
+        if (current.isActive) return false
+        current = MicrophoneRecordingSnapshot(
+            phase = MicrophoneRecordingPhase.STARTING,
+            startedAtMs = System.currentTimeMillis(),
+        )
+        return true
+    }
+
+    @Synchronized
+    fun markStarting(fileName: String) {
+        val reservedStart = current.startedAtMs
+            .takeIf { current.phase == MicrophoneRecordingPhase.STARTING }
+        current = current.copy(
+            phase = MicrophoneRecordingPhase.STARTING,
+            activeFileName = fileName,
+            bytesWritten = 0L,
+            startedAtMs = reservedStart ?: System.currentTimeMillis(),
+            error = null,
+        )
+    }
+
+    @Synchronized
+    fun markRecording(bytesWritten: Long = 0L) {
+        if (current.phase == MicrophoneRecordingPhase.FINALIZING) return
+        current = current.copy(
+            phase = MicrophoneRecordingPhase.RECORDING,
+            bytesWritten = bytesWritten,
+            error = null,
+        )
+    }
+
+    @Synchronized
+    fun markFinalizing(bytesWritten: Long) {
+        if (!current.isActive) return
+        current = current.copy(
+            phase = MicrophoneRecordingPhase.FINALIZING,
+            bytesWritten = bytesWritten,
+        )
+    }
+
+    @Synchronized
+    fun markReady(file: File, bytesWritten: Long) {
+        current = MicrophoneRecordingSnapshot(
+            phase = MicrophoneRecordingPhase.READY,
+            activeFileName = file.name,
+            bytesWritten = bytesWritten,
+            startedAtMs = current.startedAtMs,
+        )
+    }
+
+    @Synchronized
+    fun markError(message: String) {
+        current = current.copy(
+            phase = MicrophoneRecordingPhase.ERROR,
+            error = message,
+        )
+    }
+}

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/PcmSampleProcessor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/PcmSampleProcessor.kt
@@ -1,0 +1,18 @@
+package com.hermesandroid.bridge.audio
+
+import kotlin.math.roundToInt
+
+/** Deterministic PCM processing applied before samples are written to disk. */
+internal object PcmSampleProcessor {
+    internal const val RECORDING_GAIN = 2.5f
+
+    fun applyRecordingGain(samples: ShortArray, count: Int) {
+        require(count in 0..samples.size) { "Invalid sample count" }
+        for (index in 0 until count) {
+            samples[index] = (samples[index] * RECORDING_GAIN)
+                .roundToInt()
+                .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+                .toShort()
+        }
+    }
+}

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/WavFileWriter.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/audio/WavFileWriter.kt
@@ -1,0 +1,110 @@
+package com.hermesandroid.bridge.audio
+
+import java.io.Closeable
+import java.io.File
+import java.io.FileOutputStream
+import java.io.RandomAccessFile
+
+/** Streams PCM16 samples into a temporary WAV and atomically publishes it on finish. */
+internal class WavFileWriter(
+    private val pending: PendingMicrophoneRecording,
+    private val sampleRate: Int,
+) : Closeable {
+    private var output: FileOutputStream? = FileOutputStream(pending.temporaryFile)
+    private var finished = false
+    private var byteBuffer = ByteArray(0)
+
+    var totalSamples: Long = 0L
+        private set
+
+    init {
+        require(sampleRate > 0) { "sampleRate must be positive" }
+        output?.write(buildHeader(dataSize = 0L))
+    }
+
+    fun write(samples: ShortArray, count: Int) {
+        require(count in 0..samples.size) { "Invalid sample count" }
+        check(!finished) { "WAV is already finalized" }
+
+        val byteCount = count * 2
+        if (byteBuffer.size < byteCount) byteBuffer = ByteArray(byteCount)
+        for (index in 0 until count) {
+            val sample = samples[index].toInt()
+            byteBuffer[index * 2] = (sample and 0xff).toByte()
+            byteBuffer[index * 2 + 1] = ((sample ushr 8) and 0xff).toByte()
+        }
+        output?.write(byteBuffer, 0, byteCount)
+        totalSamples += count
+    }
+
+    fun finish(): File {
+        if (finished) return pending.completedFile
+        val dataSize = totalSamples * 2L
+        require(dataSize <= 0xffff_ffffL - 36L) { "Recording exceeds WAV size limit" }
+
+        output?.flush()
+        output?.fd?.sync()
+        output?.close()
+        output = null
+
+        RandomAccessFile(pending.temporaryFile, "rw").use { file ->
+            file.seek(4L)
+            writeLittleEndianInt(file, 36L + dataSize)
+            file.seek(40L)
+            writeLittleEndianInt(file, dataSize)
+            file.fd.sync()
+        }
+
+        if (pending.completedFile.exists()) {
+            throw IllegalStateException("Completed recording already exists")
+        }
+        if (!pending.temporaryFile.renameTo(pending.completedFile)) {
+            throw IllegalStateException("Could not finalize microphone recording")
+        }
+        finished = true
+        return pending.completedFile
+    }
+
+    fun abort() {
+        close()
+        pending.temporaryFile.delete()
+    }
+
+    override fun close() {
+        runCatching { output?.close() }
+        output = null
+    }
+
+    private fun buildHeader(dataSize: Long): ByteArray = ByteArray(44).also { header ->
+        "RIFF".toByteArray(Charsets.US_ASCII).copyInto(header, destinationOffset = 0)
+        writeLittleEndianInt(header, 4, 36L + dataSize)
+        "WAVE".toByteArray(Charsets.US_ASCII).copyInto(header, destinationOffset = 8)
+        "fmt ".toByteArray(Charsets.US_ASCII).copyInto(header, destinationOffset = 12)
+        writeLittleEndianInt(header, 16, 16L)
+        writeLittleEndianShort(header, 20, 1)
+        writeLittleEndianShort(header, 22, 1)
+        writeLittleEndianInt(header, 24, sampleRate.toLong())
+        writeLittleEndianInt(header, 28, sampleRate.toLong() * 2L)
+        writeLittleEndianShort(header, 32, 2)
+        writeLittleEndianShort(header, 34, 16)
+        "data".toByteArray(Charsets.US_ASCII).copyInto(header, destinationOffset = 36)
+        writeLittleEndianInt(header, 40, dataSize)
+    }
+
+    private fun writeLittleEndianInt(buffer: ByteArray, offset: Int, value: Long) {
+        for (byteIndex in 0 until 4) {
+            buffer[offset + byteIndex] = ((value ushr (byteIndex * 8)) and 0xff).toByte()
+        }
+    }
+
+    private fun writeLittleEndianShort(buffer: ByteArray, offset: Int, value: Int) {
+        buffer[offset] = (value and 0xff).toByte()
+        buffer[offset + 1] = ((value ushr 8) and 0xff).toByte()
+    }
+
+    private fun writeLittleEndianInt(file: RandomAccessFile, value: Long) {
+        for (byteIndex in 0 until 4) {
+            file.write(((value ushr (byteIndex * 8)) and 0xff).toInt())
+        }
+    }
+}

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/client/RelayClient.kt
@@ -3,14 +3,19 @@ package com.hermesandroid.bridge.client
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import com.hermesandroid.bridge.BridgeApplication
 import com.hermesandroid.bridge.BuildConfig
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.hermesandroid.bridge.audio.MicrophoneRecordingFiles
 import com.hermesandroid.bridge.server.CommandDispatcher
 import com.hermesandroid.bridge.service.BridgeAccessibilityService
 import kotlinx.coroutines.*
 import okhttp3.*
+import okio.ByteString.Companion.toByteString
+import java.io.FileInputStream
+import java.security.MessageDigest
 
 /**
  * WebSocket client that connects OUT to the Hermes relay server.
@@ -294,6 +299,18 @@ object RelayClient {
 
             if (BuildConfig.DEBUG) Log.d(TAG, "Received command: $method $path (id=$requestId)")
 
+            if (requestId.isBlank()) {
+                throw IllegalArgumentException("Command is missing request_id")
+            }
+            if (method == "GET" && path == "/mic_file") {
+                streamMicrophoneRecording(
+                    ws,
+                    requestId,
+                    params.get("name")?.asString,
+                )
+                return
+            }
+
             // The relay connection is authenticated at connect time (Bearer token on the WS handshake),
             // so commands arriving here are already authenticated.
             val response = CommandDispatcher.dispatch(method, path, params, body, authenticated = true)
@@ -317,6 +334,123 @@ object RelayClient {
                 ws.send(errorResponse.toString())
             } catch (_: Exception) {}
         }
+    }
+
+    private suspend fun streamMicrophoneRecording(
+        ws: WebSocket,
+        requestId: String,
+        requestedName: String?,
+    ) {
+        val file = MicrophoneRecordingFiles.resolve(
+            BridgeApplication.instance,
+            requestedName,
+        )
+        if (file == null) {
+            sendCommandResult(
+                ws,
+                requestId,
+                mapOf("error" to "Recording not found"),
+                status = 404,
+            )
+            return
+        }
+
+        val startMessage = JsonObject().apply {
+            addProperty("request_id", requestId)
+            addProperty("status", 200)
+            add("stream", JsonObject().apply {
+                addProperty("event", "start")
+                addProperty("filename", file.name)
+                addProperty("mimeType", "audio/wav")
+                addProperty("size", file.length())
+            })
+        }
+        if (!ws.send(startMessage.toString())) return
+
+        val digest = MessageDigest.getInstance("SHA-256")
+        var bytesSent = 0L
+        try {
+            FileInputStream(file).use { input ->
+                val buffer = ByteArray(64 * 1024)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    if (read == 0) continue
+
+                    while (ws.queueSize() > 1024L * 1024L) {
+                        delay(10L)
+                    }
+                    digest.update(buffer, 0, read)
+                    if (!ws.send(buildStreamFrame(requestId, buffer, read))) {
+                        throw IllegalStateException("WebSocket rejected microphone stream data")
+                    }
+                    bytesSent += read
+                }
+            }
+
+            val endMessage = JsonObject().apply {
+                addProperty("request_id", requestId)
+                addProperty("status", 200)
+                add("stream", JsonObject().apply {
+                    addProperty("event", "end")
+                    addProperty("bytes", bytesSent)
+                    addProperty(
+                        "sha256",
+                        digest.digest().joinToString("") { byte ->
+                            "%02x".format(byte.toInt() and 0xff)
+                        },
+                    )
+                })
+            }
+            ws.send(endMessage.toString())
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            val errorMessage = JsonObject().apply {
+                addProperty("request_id", requestId)
+                addProperty("status", 500)
+                add("stream", JsonObject().apply {
+                    addProperty("event", "error")
+                    addProperty("message", "Microphone stream failed (${error.javaClass.simpleName})")
+                })
+            }
+            ws.send(errorMessage.toString())
+        }
+    }
+
+    private fun buildStreamFrame(
+        requestId: String,
+        payload: ByteArray,
+        payloadLength: Int,
+    ): okio.ByteString {
+        val requestIdBytes = requestId.toByteArray(Charsets.UTF_8)
+        require(requestIdBytes.size in 1..128) { "request_id is too long" }
+        require(payloadLength in 0..payload.size) { "Invalid payload length" }
+
+        val frame = ByteArray(2 + requestIdBytes.size + payloadLength)
+        frame[0] = ((requestIdBytes.size ushr 8) and 0xff).toByte()
+        frame[1] = (requestIdBytes.size and 0xff).toByte()
+        requestIdBytes.copyInto(frame, destinationOffset = 2)
+        payload.copyInto(
+            frame,
+            destinationOffset = 2 + requestIdBytes.size,
+            endIndex = payloadLength,
+        )
+        return frame.toByteString()
+    }
+
+    private fun sendCommandResult(
+        ws: WebSocket,
+        requestId: String,
+        result: Any,
+        status: Int,
+    ) {
+        val response = JsonObject().apply {
+            addProperty("request_id", requestId)
+            add("result", gson.toJsonTree(result))
+            addProperty("status", status)
+        }
+        ws.send(response.toString())
     }
 
     private fun notifyStatus(connected: Boolean, message: String) {

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/BridgeRouter.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/BridgeRouter.kt
@@ -2,7 +2,9 @@ package com.hermesandroid.bridge.server
 
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.hermesandroid.bridge.BridgeApplication
 import com.hermesandroid.bridge.auth.PairingManager
+import com.hermesandroid.bridge.audio.MicrophoneRecordingFiles
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
@@ -19,6 +21,26 @@ import io.ktor.server.routing.*
  */
 fun Application.configureRouting() {
     routing {
+        get("/mic_file") {
+            val requestedName = call.request.queryParameters["name"]
+            val file = MicrophoneRecordingFiles.resolve(
+                BridgeApplication.instance,
+                requestedName,
+            )
+            if (file == null) {
+                call.respond(HttpStatusCode.NotFound, mapOf("error" to "Recording not found"))
+                return@get
+            }
+
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.response.header(HttpHeaders.ContentType, "audio/wav")
+            call.response.header(
+                HttpHeaders.ContentDisposition,
+                "attachment; filename=\"${file.name}\"",
+            )
+            call.respondFile(file)
+        }
+
         route("{path...}") {
             handle {
                 val method = call.request.httpMethod.value.uppercase()

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -2,7 +2,13 @@
 
 package com.hermesandroid.bridge.server
 
+import android.Manifest
+import android.content.pm.PackageManager
 import com.google.gson.JsonObject
+import com.hermesandroid.bridge.BridgeApplication
+import com.hermesandroid.bridge.audio.MicrophoneRecorderService
+import com.hermesandroid.bridge.audio.MicrophoneRecordingFiles
+import com.hermesandroid.bridge.audio.MicrophoneRecordingState
 import com.hermesandroid.bridge.event.EventStore
 import com.hermesandroid.bridge.executor.ActionExecutor
 import com.hermesandroid.bridge.executor.ScreenReader
@@ -24,7 +30,7 @@ import kotlinx.coroutines.withContext
  * so endpoint contracts, device-capability gating, and behaviour live in exactly one place.
  *
  * @param authenticated whether the caller is authenticated. The relay connection is
- *   authenticated at connect time (token in the WS URL), so it passes `true`; the HTTP
+ *   authenticated at connect time (Bearer token in the WS handshake), so it passes `true`; the HTTP
  *   server computes it from the request's Bearer token. Only `/ping` reports it back.
  */
 object CommandDispatcher {
@@ -346,6 +352,78 @@ object CommandDispatcher {
             method == "POST" && path == "/stop_speaking" -> {
                 val result = ActionExecutor.stopSpeaking()
                 result to 200
+            }
+
+            method == "POST" && path == "/mic_start" -> {
+                val durationValue = body.get("duration")
+                val durationSec = when {
+                    durationValue == null -> 0
+                    !durationValue.isJsonPrimitive || !durationValue.asJsonPrimitive.isNumber -> {
+                        return mapOf("error" to "duration must be an integer number of seconds") to 400
+                    }
+                    else -> durationValue.asJsonPrimitive.asString.toIntOrNull()
+                        ?: return mapOf("error" to "duration must be an integer number of seconds") to 400
+                }
+                val app = BridgeApplication.instance
+                if (durationSec !in 0..MicrophoneRecorderService.MAX_DURATION_SECONDS) {
+                    return mapOf(
+                        "error" to "duration must be between 0 and ${MicrophoneRecorderService.MAX_DURATION_SECONDS} seconds"
+                    ) to 400
+                }
+                if (app.checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+                    return mapOf("error" to "Microphone permission is not granted") to 403
+                }
+                if (!MicrophoneRecordingState.tryReserveStart()) {
+                    return mapOf("error" to "A microphone recording is already active") to 409
+                }
+
+                runCatching {
+                    MicrophoneRecorderService.start(app, durationSec)
+                    mapOf(
+                        "status" to "starting",
+                        "duration" to durationSec,
+                    ) to 202
+                }.getOrElse { error ->
+                    MicrophoneRecordingState.markError(
+                        "Could not start microphone service (${error.javaClass.simpleName})",
+                    )
+                    mapOf(
+                        "error" to "Could not start microphone service (${error.javaClass.simpleName})"
+                    ) to 500
+                }
+            }
+
+            method == "POST" && path == "/mic_stop" -> {
+                val snapshot = MicrophoneRecordingState.snapshot()
+                if (!snapshot.isActive) {
+                    return mapOf("status" to "idle") to 200
+                }
+                runCatching {
+                    MicrophoneRecorderService.stop(BridgeApplication.instance)
+                    mapOf("status" to "stopping") to 202
+                }.getOrElse { error ->
+                    mapOf(
+                        "error" to "Could not stop microphone service (${error.javaClass.simpleName})"
+                    ) to 500
+                }
+            }
+
+            method == "GET" && path == "/mic_status" -> {
+                val app = BridgeApplication.instance
+                val snapshot = MicrophoneRecordingState.snapshot()
+                val files = MicrophoneRecordingFiles.listCompleted(app)
+                val latest = files.firstOrNull()
+                mapOf(
+                    "phase" to snapshot.phase.name.lowercase(),
+                    "recording" to snapshot.isActive,
+                    "count" to files.size,
+                    "retentionLimit" to MicrophoneRecordingFiles.MAX_COMPLETED_RECORDINGS,
+                    "latest" to latest?.name,
+                    "latestSize" to latest?.length(),
+                    "bytesWritten" to snapshot.bytesWritten,
+                    "startedAt" to snapshot.startedAtMs,
+                    "error" to snapshot.error,
+                ) to 200
             }
 
             method == "POST" && path == "/screen_record" -> {

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeNotificationListener.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/service/BridgeNotificationListener.kt
@@ -31,7 +31,7 @@ class BridgeNotificationListener : NotificationListenerService() {
         val entry = NotificationStore.parseNotification(sbn)
         if (entry != null) {
             NotificationStore.add(entry)
-            if (BuildConfig.DEBUG) Log.d(TAG, "Notification from ${entry.packageName}: ${entry.text?.take(50)}")
+            if (BuildConfig.DEBUG) Log.d(TAG, "Notification received and stored")
         }
     }
 

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingFilesTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingFilesTest.kt
@@ -1,0 +1,36 @@
+package com.hermesandroid.bridge.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MicrophoneRecordingFilesTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `retention keeps newest WAVs and ignores incomplete or unrelated files`() {
+        val directory = temporaryFolder.newFolder("recordings")
+        val recordings = (1..4).map { index ->
+            directory.resolve("recording_$index.wav").apply {
+                writeBytes(byteArrayOf(index.toByte()))
+                assertTrue(setLastModified(index * 1_000L))
+            }
+        }
+        val incomplete = directory.resolve("recording_5.wav.part").apply { writeText("partial") }
+        val unrelated = directory.resolve("notes.txt").apply { writeText("keep") }
+
+        val deleted = MicrophoneRecordingFiles.enforceRetention(directory, keepLast = 2)
+
+        assertEquals(2, deleted)
+        assertFalse(recordings[0].exists())
+        assertFalse(recordings[1].exists())
+        assertTrue(recordings[2].exists())
+        assertTrue(recordings[3].exists())
+        assertTrue(incomplete.exists())
+        assertTrue(unrelated.exists())
+    }
+}

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingStateTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/MicrophoneRecordingStateTest.kt
@@ -1,0 +1,38 @@
+package com.hermesandroid.bridge.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class MicrophoneRecordingStateTest {
+    @Before
+    fun resetState() {
+        MicrophoneRecordingState.markError("test reset")
+    }
+
+    @Test
+    fun `only one start can reserve the recorder`() {
+        assertTrue(MicrophoneRecordingState.tryReserveStart())
+        assertFalse(MicrophoneRecordingState.tryReserveStart())
+        assertEquals(
+            MicrophoneRecordingPhase.STARTING,
+            MicrophoneRecordingState.snapshot().phase,
+        )
+    }
+
+    @Test
+    fun `late audio progress cannot leave finalizing state`() {
+        assertTrue(MicrophoneRecordingState.tryReserveStart())
+        MicrophoneRecordingState.markStarting("recording_test.wav")
+        MicrophoneRecordingState.markRecording(bytesWritten = 128L)
+        MicrophoneRecordingState.markFinalizing(bytesWritten = 128L)
+
+        MicrophoneRecordingState.markRecording(bytesWritten = 256L)
+
+        val snapshot = MicrophoneRecordingState.snapshot()
+        assertEquals(MicrophoneRecordingPhase.FINALIZING, snapshot.phase)
+        assertEquals(128L, snapshot.bytesWritten)
+    }
+}

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/PcmSampleProcessorTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/PcmSampleProcessorTest.kt
@@ -1,0 +1,18 @@
+package com.hermesandroid.bridge.audio
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class PcmSampleProcessorTest {
+    @Test
+    fun `recording gain amplifies and saturates without touching unread samples`() {
+        val samples = shortArrayOf(1_000, -1_000, 20_000, -20_000, 0, 123)
+
+        PcmSampleProcessor.applyRecordingGain(samples, count = 5)
+
+        assertArrayEquals(
+            shortArrayOf(2_500, -2_500, Short.MAX_VALUE, Short.MIN_VALUE, 0, 123),
+            samples,
+        )
+    }
+}

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/WavFileWriterTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/audio/WavFileWriterTest.kt
@@ -1,0 +1,64 @@
+package com.hermesandroid.bridge.audio
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class WavFileWriterTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `finish publishes valid PCM16 WAV and removes temporary file`() {
+        val directory = temporaryFolder.newFolder("audio")
+        val pending = PendingMicrophoneRecording(
+            temporaryFile = directory.resolve("recording.wav.part"),
+            completedFile = directory.resolve("recording.wav"),
+        )
+        val samples = shortArrayOf(0, 32767, -32768, -1)
+
+        val completed = WavFileWriter(pending, sampleRate = 16_000).use { writer ->
+            writer.write(samples, samples.size)
+            writer.finish()
+        }
+
+        val bytes = completed.readBytes()
+        assertFalse(pending.temporaryFile.exists())
+        assertTrue(completed.exists())
+        assertEquals(44 + samples.size * 2, bytes.size)
+        assertArrayEquals("RIFF".toByteArray(), bytes.copyOfRange(0, 4))
+        assertArrayEquals("WAVE".toByteArray(), bytes.copyOfRange(8, 12))
+        assertArrayEquals("data".toByteArray(), bytes.copyOfRange(36, 40))
+        assertEquals(bytes.size - 8, littleEndianInt(bytes, 4))
+        assertEquals(samples.size * 2, littleEndianInt(bytes, 40))
+        assertArrayEquals(
+            byteArrayOf(0, 0, -1, 127, 0, -128, -1, -1),
+            bytes.copyOfRange(44, bytes.size),
+        )
+    }
+
+    @Test
+    fun `abort removes incomplete recording`() {
+        val directory = temporaryFolder.newFolder("aborted")
+        val pending = PendingMicrophoneRecording(
+            temporaryFile = directory.resolve("recording.wav.part"),
+            completedFile = directory.resolve("recording.wav"),
+        )
+        val writer = WavFileWriter(pending, sampleRate = 16_000)
+        writer.write(shortArrayOf(1, 2), 2)
+
+        writer.abort()
+
+        assertFalse(pending.temporaryFile.exists())
+        assertFalse(pending.completedFile.exists())
+    }
+
+    private fun littleEndianInt(bytes: ByteArray, offset: Int): Int =
+        ByteBuffer.wrap(bytes, offset, 4).order(ByteOrder.LITTLE_ENDIAN).int
+}

--- a/hermes-android-plugin/__init__.py
+++ b/hermes-android-plugin/__init__.py
@@ -1,6 +1,6 @@
 """
-hermes-android plugin — registers 14 android_* tools into hermes-agent via the
-v0.3.0 plugin system.
+hermes-android plugin — registers 42 android_* tools through the hermes-agent
+plugin system.
 
 Drop this folder into ~/.hermes/plugins/hermes-android and restart hermes.
 """

--- a/hermes-android-plugin/android_relay.py
+++ b/hermes-android-plugin/android_relay.py
@@ -24,10 +24,12 @@ Command JSON format:
 # to enable wss:// connections. Without these, the relay uses plaintext http.
 
 import asyncio
+import hashlib
 import hmac
 import json
 import logging
 import os
+import re
 import threading
 import time
 import uuid
@@ -67,6 +69,11 @@ class _RelayState:
         # Pending requests: request_id -> asyncio.Future
         self.pending: dict[str, asyncio.Future] = {}
         self.pending_lock: Optional[asyncio.Lock] = None  # created lazily
+
+        # Binary HTTP responses (currently microphone WAV downloads):
+        # request_id -> bounded queue of ("message"|"chunk"|"error", payload).
+        self.streams: dict[str, asyncio.Queue] = {}
+        self.streams_lock: Optional[asyncio.Lock] = None
 
         # Shutdown event
         self.shutdown_event: Optional[asyncio.Event] = None
@@ -164,6 +171,7 @@ def _run_loop(state: _RelayState, ready: threading.Event) -> None:
     state.loop = loop
     state.phone_ws_lock = asyncio.Lock()
     state.pending_lock = asyncio.Lock()
+    state.streams_lock = asyncio.Lock()
     state.shutdown_event = asyncio.Event()
 
     try:
@@ -196,7 +204,10 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
     state.app = app
 
     # WebSocket endpoint
-    app.router.add_get("/ws", lambda req: _handle_ws(req, state))
+    async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
+        return await _handle_ws(request, state)
+
+    app.router.add_get("/ws", websocket_handler)
 
     # HTTP bridge endpoints — method per path
     ROUTES = {
@@ -212,6 +223,8 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
         "/screen_hash":   "GET",
         "/location":      "GET",
         "/widgets":       "GET",
+        "/mic_status":    "GET",
+        "/mic_file":      "GET",
         # POST-only
         "/tap":           "POST",
         "/tap_text":      "POST",
@@ -236,12 +249,16 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
         "/stop_speaking": "POST",
         "/screen_record": "POST",
         "/events/stream": "POST",
+        "/mic_start":     "POST",
+        "/mic_stop":      "POST",
         # READ + WRITE
         "/clipboard":     "BOTH",
     }
 
     for path, method in ROUTES.items():
-        handler = lambda req, p=path: _handle_http(req, state, p)
+        async def handler(request: web.Request, route_path: str = path) -> web.StreamResponse:
+            return await _handle_http(request, state, route_path)
+
         if method in ("GET", "BOTH"):
             app.router.add_get(path, handler)
         if method in ("POST", "BOTH"):
@@ -267,7 +284,6 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
             "to enable TLS. Binding to %s without TLS is insecure for internet-facing use.",
             host,
         )
-
     ready.set()
 
     # Block until shutdown is signalled
@@ -357,7 +373,8 @@ def _auth_record_failure(ip: str) -> None:
 
 
 def _mask_token(token: str) -> str:
-    return (token[:2] + "****") if len(token) >= 2 else "****"
+    # Never emit even a prefix: the pairing token grants full device control.
+    return "****"
 
 
 # Request-body fields that may carry PII or secrets (phone numbers, SMS text,
@@ -413,6 +430,7 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     async with state.phone_ws_lock:
         if state.phone_ws is not None and not state.phone_ws.closed:
             logger.info("Replacing previous phone connection")
+            await _fail_inflight(state, reason="phone connection replaced")
             await state.phone_ws.close(
                 code=aiohttp.WSCloseCode.GOING_AWAY, message=b"replaced"
             )
@@ -424,11 +442,13 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
         async for msg in ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
                 await _on_phone_message(state, msg.data)
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                await _on_phone_binary(state, msg.data)
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 logger.error("Phone WS error: %s", ws.exception())
                 break
     finally:
-        await _cleanup_phone(state, reason="phone disconnected")
+        await _cleanup_phone(state, reason="phone disconnected", expected_ws=ws)
 
     return ws
 
@@ -446,6 +466,12 @@ async def _on_phone_message(state: _RelayState, raw: str) -> None:
         logger.warning("Phone message missing request_id: %s", raw[:200])
         return
 
+    async with state.streams_lock:
+        stream_queue = state.streams.get(request_id)
+    if stream_queue is not None:
+        await stream_queue.put(("message", data))
+        return
+
     async with state.pending_lock:
         future = state.pending.pop(request_id, None)
 
@@ -459,15 +485,57 @@ async def _on_phone_message(state: _RelayState, raw: str) -> None:
         future.set_result(data)
 
 
-async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
+def _decode_stream_frame(raw: bytes) -> tuple[str, bytes]:
+    """Decode a binary phone frame: uint16 request-id length, UTF-8 id, payload."""
+    if len(raw) < 3:
+        raise ValueError("Binary stream frame is too short")
+    request_id_length = int.from_bytes(raw[:2], byteorder="big", signed=False)
+    if request_id_length < 1 or request_id_length > 128:
+        raise ValueError("Binary stream frame has an invalid request-id length")
+    payload_offset = 2 + request_id_length
+    if payload_offset > len(raw):
+        raise ValueError("Binary stream frame is truncated")
+    request_id = raw[2:payload_offset].decode("utf-8")
+    return request_id, raw[payload_offset:]
+
+
+async def _on_phone_binary(state: _RelayState, raw: bytes) -> None:
+    try:
+        request_id, payload = _decode_stream_frame(raw)
+    except (UnicodeDecodeError, ValueError) as exc:
+        logger.warning("Invalid binary stream frame from phone: %s", exc)
+        return
+
+    async with state.streams_lock:
+        stream_queue = state.streams.get(request_id)
+    if stream_queue is None:
+        logger.debug("No active stream for request_id=%s", request_id)
+        return
+    await stream_queue.put(("chunk", payload))
+
+
+async def _cleanup_phone(
+    state: _RelayState,
+    reason: str = "",
+    expected_ws: Optional[web.WebSocketResponse] = None,
+) -> None:
     """Clean up phone connection and cancel all pending requests."""
     async with state.phone_ws_lock:
+        # A newly connected phone may already have replaced this socket. The
+        # old handler must not tear down the replacement or its active requests.
+        if expected_ws is not None and state.phone_ws is not expected_ws:
+            return
         ws = state.phone_ws
         state.phone_ws = None
 
     if ws is not None and not ws.closed:
         await ws.close()
 
+    await _fail_inflight(state, reason)
+
+
+async def _fail_inflight(state: _RelayState, reason: str) -> None:
+    """Fail requests that were assigned to a phone connection that is gone."""
     # Fail all pending futures
     async with state.pending_lock:
         pending = dict(state.pending)
@@ -476,6 +544,17 @@ async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
     for rid, fut in pending.items():
         if not fut.done():
             fut.set_exception(ConnectionError(f"Phone disconnected ({reason})"))
+
+    async with state.streams_lock:
+        stream_queues = list(state.streams.values())
+        state.streams.clear()
+    for queue in stream_queues:
+        while not queue.empty():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        queue.put_nowait(("error", f"Phone disconnected ({reason})"))
 
     if pending:
         logger.info("Cancelled %d pending requests (%s)", len(pending), reason)
@@ -488,7 +567,7 @@ _RESPONSE_TIMEOUT = 30  # seconds
 
 async def _handle_http(
     request: web.Request, state: _RelayState, path: str
-) -> web.Response:
+) -> web.StreamResponse:
     """Forward an HTTP request from a tool to the phone over WebSocket."""
     # ── Auth check ──────────────────────────────────────────────────────────
     # Require Bearer token matching the pairing code.  The client already sends
@@ -544,21 +623,36 @@ async def _handle_http(
     }
     logger.debug(">>> %s %s body=%s", method, path, _safe_body_repr(body))
 
-    # Register a future *before* sending so we never miss the reply
-    future = state.loop.create_future()
-    async with state.pending_lock:
-        state.pending[request_id] = future
+    # Register the response target *before* sending so we never miss a reply.
+    is_binary_stream = path == "/mic_file"
+    future = None
+    stream_queue = None
+    if is_binary_stream:
+        stream_queue = asyncio.Queue(maxsize=8)
+        async with state.streams_lock:
+            state.streams[request_id] = stream_queue
+    else:
+        future = state.loop.create_future()
+        async with state.pending_lock:
+            state.pending[request_id] = future
 
     try:
         await ws.send_json(command)
     except Exception as exc:
-        async with state.pending_lock:
-            state.pending.pop(request_id, None)
+        if is_binary_stream:
+            async with state.streams_lock:
+                state.streams.pop(request_id, None)
+        else:
+            async with state.pending_lock:
+                state.pending.pop(request_id, None)
         logger.error("Failed to send command to phone: %s", exc)
         return web.json_response(
             {"error": f"Failed to send command to phone: {exc}"},
             status=502,
         )
+
+    if is_binary_stream:
+        return await _relay_binary_stream(request, state, request_id, stream_queue)
 
     # Wait for the phone's response
     try:
@@ -583,3 +677,106 @@ async def _handle_http(
     status = response_data.get("status", 200)
     result = response_data.get("result", {})
     return web.json_response(result, status=status)
+
+
+_MAX_STREAM_BYTES = 256 * 1024 * 1024
+
+
+async def _relay_binary_stream(
+    request: web.Request,
+    state: _RelayState,
+    request_id: str,
+    queue: asyncio.Queue,
+) -> web.StreamResponse:
+    """Stream binary phone frames to the authenticated HTTP caller with backpressure."""
+    response = None
+    try:
+        kind, first = await asyncio.wait_for(queue.get(), timeout=_RESPONSE_TIMEOUT)
+        if kind == "error":
+            return web.json_response({"error": first}, status=502)
+        if kind != "message":
+            return web.json_response({"error": "Phone sent stream data before metadata"}, status=502)
+
+        stream = first.get("stream") if isinstance(first, dict) else None
+        if not isinstance(stream, dict) or stream.get("event") != "start":
+            status = first.get("status", 502) if isinstance(first, dict) else 502
+            result = first.get("result", {"error": "Invalid stream response"}) if isinstance(first, dict) else {"error": "Invalid stream response"}
+            return web.json_response(result, status=status)
+
+        expected_size = int(stream.get("size", -1))
+        if expected_size < 0 or expected_size > _MAX_STREAM_BYTES:
+            return web.json_response({"error": "Recording size is invalid"}, status=413)
+
+        raw_filename = os.path.basename(str(stream.get("filename", "recording.wav")))
+        filename = re.sub(r"[^A-Za-z0-9._-]", "_", raw_filename)
+        if not filename.lower().endswith(".wav"):
+            filename = "recording.wav"
+        mime_type = str(stream.get("mimeType", "audio/wav"))
+        if mime_type != "audio/wav":
+            mime_type = "application/octet-stream"
+
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Type": mime_type,
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length": str(expected_size),
+            },
+        )
+        await response.prepare(request)
+
+        digest = hashlib.sha256()
+        total = 0
+        while True:
+            kind, payload = await asyncio.wait_for(queue.get(), timeout=_RESPONSE_TIMEOUT)
+            if kind == "error":
+                raise ConnectionError(str(payload))
+            if kind == "chunk":
+                total += len(payload)
+                if total > expected_size or total > _MAX_STREAM_BYTES:
+                    raise ValueError("Phone sent more recording data than declared")
+                digest.update(payload)
+                await response.write(payload)
+                continue
+            if kind != "message":
+                raise ValueError("Unknown stream event")
+
+            stream_event = payload.get("stream") if isinstance(payload, dict) else None
+            event_name = stream_event.get("event") if isinstance(stream_event, dict) else None
+            if event_name == "error":
+                raise IOError(str(stream_event.get("message", "Phone stream failed")))
+            if event_name != "end":
+                raise ValueError("Invalid stream completion event")
+            if total != expected_size or int(stream_event.get("bytes", -1)) != total:
+                raise IOError("Recording stream length does not match metadata")
+            expected_sha = str(stream_event.get("sha256", ""))
+            if not re.fullmatch(r"[0-9a-f]{64}", expected_sha) or not hmac.compare_digest(
+                digest.hexdigest(), expected_sha
+            ):
+                raise IOError("Recording stream checksum mismatch")
+            await response.write_eof()
+            return response
+    except asyncio.TimeoutError:
+        logger.warning("Timed out receiving microphone stream request_id=%s", request_id)
+        if response is None:
+            return web.json_response({"error": "Phone stream timed out"}, status=504)
+        response.force_close()
+        return response
+    except Exception as exc:
+        logger.warning("Microphone stream failed request_id=%s: %s", request_id, exc)
+        if response is None:
+            return web.json_response({"error": "Phone stream failed"}, status=502)
+        response.force_close()
+        return response
+    finally:
+        async with state.streams_lock:
+            if state.streams.get(request_id) is queue:
+                state.streams.pop(request_id, None)
+        # If the HTTP consumer disappeared while the bounded queue was full,
+        # free any waiting WebSocket producer immediately.
+        while not queue.empty():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break

--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -1,5 +1,5 @@
 """
-hermes-android tool — 38 android_* tool handlers + schemas.
+hermes-android tool — 42 android_* tool handlers + schemas.
 
 NOTE: This file must be kept in sync with tools/android_tool.py.
       The only difference is the import path for android_relay (see android_setup).
@@ -595,6 +595,109 @@ def android_screen_record(duration_ms: int = 5000) -> str:
         return json.dumps({"error": str(e)})
 
 
+def android_mic_record(duration: int = 0) -> str:
+    """Start PCM16/WAV recording; duration=0 records until stopped (30-minute cap)."""
+    if isinstance(duration, bool) or not isinstance(duration, int) or duration < 0 or duration > 1800:
+        return json.dumps({"error": "duration must be between 0 and 1800 seconds"})
+    try:
+        return json.dumps(_post("/mic_start", {"duration": duration}))
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_mic_stop() -> str:
+    """Stop the active microphone recording and finalize its WAV file."""
+    try:
+        return json.dumps(_post("/mic_stop", {}))
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_mic_status() -> str:
+    """Return recorder phase plus metadata for the latest completed WAV."""
+    try:
+        return json.dumps(_get("/mic_status"))
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_mic_fetch(remote_path: str = "") -> str:
+    """Stream the latest (or named) WAV to a temporary local MEDIA path."""
+    if not isinstance(remote_path, str):
+        return json.dumps({"error": "remote_path must be a WAV filename"})
+    if remote_path and (
+        os.path.basename(remote_path) != remote_path
+        or not remote_path.lower().endswith(".wav")
+    ):
+        return json.dumps({"error": "remote_path must be a WAV filename, not a path"})
+
+    import tempfile
+
+    temp_path = None
+    try:
+        params = {"name": remote_path} if remote_path else None
+        with requests.get(
+            f"{_bridge_url()}/mic_file",
+            params=params,
+            headers=_auth_headers(),
+            timeout=_timeout(),
+            stream=True,
+        ) as response:
+            if response.status_code >= 400:
+                try:
+                    return json.dumps(response.json())
+                except ValueError:
+                    return json.dumps({"error": f"Microphone download failed (HTTP {response.status_code})"})
+
+            expected = response.headers.get("Content-Length")
+            expected_size = int(expected) if expected and expected.isdigit() else None
+            if expected_size is not None and expected_size > 256 * 1024 * 1024:
+                return json.dumps({"error": "Microphone recording exceeds the download limit"})
+
+            written = 0
+            prefix = bytearray()
+            with tempfile.NamedTemporaryFile(
+                suffix=".wav",
+                prefix="android_mic_",
+                delete=False,
+            ) as output:
+                temp_path = output.name
+                for chunk in response.iter_content(chunk_size=64 * 1024):
+                    if not chunk:
+                        continue
+                    written += len(chunk)
+                    if written > 256 * 1024 * 1024:
+                        raise ValueError("Microphone recording exceeds the download limit")
+                    if len(prefix) < 12:
+                        prefix.extend(chunk[: 12 - len(prefix)])
+                    output.write(chunk)
+
+        if expected_size is not None and written != expected_size:
+            raise IOError("Microphone recording download was incomplete")
+        if len(prefix) < 12 or prefix[:4] != b"RIFF" or prefix[8:12] != b"WAVE":
+            raise IOError("Downloaded microphone recording is not a WAV file")
+        return f"Microphone recording fetched ({written} bytes)\nMEDIA:{temp_path}"
+    except Exception as e:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+        return json.dumps({"error": str(e)})
+
+
+def android_read_widgets() -> str:
+    """
+    Read home screen widgets (weather, calendar, tasks, etc.) without
+    opening apps. Goes to home screen first, then reads widget content.
+    """
+    try:
+        data = _get("/widgets")
+        return json.dumps(data)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
 def android_find_nodes(
     text: str = None, class_name: str = None, clickable: bool = None, limit: int = 20
 ) -> str:
@@ -638,18 +741,6 @@ def android_pinch(x: int, y: int, scale: float = 1.5, duration: int = 300) -> st
     """
     try:
         data = _post("/pinch", {"x": x, "y": y, "scale": scale, "duration": duration})
-        return json.dumps(data)
-    except Exception as e:
-        return json.dumps({"error": str(e)})
-
-
-def android_read_widgets() -> str:
-    """
-    Read home screen widgets (weather, calendar, tasks, etc.) without
-    opening apps. Goes to home screen first, then reads widget content.
-    """
-    try:
-        data = _get("/widgets")
         return json.dumps(data)
     except Exception as e:
         return json.dumps({"error": str(e)})
@@ -1279,6 +1370,49 @@ _SCHEMAS = {
             "required": [],
         },
     },
+    "android_mic_record": {
+        "name": "android_mic_record",
+        "description": "Start a 16 kHz mono WAV microphone recording on the Android device.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "duration": {
+                    "type": "integer",
+                    "description": "Seconds to record (0 records until android_mic_stop, capped at 1800; maximum 1800)",
+                    "minimum": 0,
+                    "maximum": 1800,
+                    "default": 0,
+                },
+            },
+            "required": [],
+        },
+    },
+    "android_mic_stop": {
+        "name": "android_mic_stop",
+        "description": "Stop the active microphone recording and finalize its WAV file.",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_mic_status": {
+        "name": "android_mic_status",
+        "description": "Get microphone recorder state and latest completed WAV metadata.",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_mic_fetch": {
+        "name": "android_mic_fetch",
+        "description": "Download the latest or named microphone WAV as a local MEDIA file.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "remote_path": {
+                    "type": "string",
+                    "description": "Optional WAV filename returned by android_mic_status; paths are rejected",
+                    "default": "",
+                },
+            },
+            "required": [],
+        },
+    },
+
     "android_read_widgets": {
         "name": "android_read_widgets",
         "description": "Read home screen widgets (weather, calendar, tasks, etc.). Goes to home screen and reads widget content without opening apps.",
@@ -1457,6 +1591,10 @@ _HANDLERS = {
     "android_events": lambda args, **kw: android_events(**args),
     "android_event_stream": lambda args, **kw: android_event_stream(**args),
     "android_screen_record": lambda args, **kw: android_screen_record(**args),
+    "android_mic_record": lambda args, **kw: android_mic_record(**args),
+    "android_mic_stop": lambda args, **kw: android_mic_stop(),
+    "android_mic_status": lambda args, **kw: android_mic_status(),
+    "android_mic_fetch": lambda args, **kw: android_mic_fetch(**args),
     "android_read_widgets": lambda args, **kw: android_read_widgets(),
     "android_find_nodes": lambda args, **kw: android_find_nodes(**args),
     "android_diff_screen": lambda args, **kw: android_diff_screen(**args),

--- a/hermes-android-plugin/plugin.yaml
+++ b/hermes-android-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-android
-version: 0.3.0
+version: 0.4.1
 description: "Remote Android device control — read screen, tap, type, open apps, take screenshots via the Hermes Bridge companion app"
 author: raulvidis
 requires_env: []

--- a/hermes-android-plugin/skill.md
+++ b/hermes-android-plugin/skill.md
@@ -48,7 +48,7 @@ After the user taps Connect on their phone, the phone connects to this server vi
 
 ## Available Tools
 
-You have these 38 tools. Use them by name — they are function calls.
+You have these 42 tools. Use them by name — they are function calls.
 
 ### Connectivity
 - `android_ping()` — check if phone is connected and responding
@@ -79,6 +79,12 @@ You have these 38 tools. Use them by name — they are function calls.
 
 ### Waiting
 - `android_wait(text, class_name, timeout_ms=5000)` — poll until an element appears. Use after navigation or loading.
+
+### Microphone
+- `android_mic_record(duration=0)` — start a visible 16 kHz mono recording; `0` records until stopped, with a 30-minute safety cap.
+- `android_mic_stop()` — stop and finalize the WAV.
+- `android_mic_status()` — inspect recorder phase and completed-file metadata.
+- `android_mic_fetch(remote_path="")` — stream the latest or named WAV to a temporary `MEDIA:` file.
 
 ## Rules
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="hermes-android",
-    version="0.3.0",
+    version="0.4.1",
     packages=find_packages(),
     install_requires=[
         "requests>=2.28.0",

--- a/skills/android/SKILL.md
+++ b/skills/android/SKILL.md
@@ -48,7 +48,7 @@ After the user taps Connect on their phone, the phone connects to this server vi
 
 ## Available Tools
 
-You have these 38 tools. Use them by name — they are function calls.
+You have these 42 tools. Use them by name — they are function calls.
 
 ### Connectivity
 - `android_ping()` — check if phone is connected and responding
@@ -79,6 +79,12 @@ You have these 38 tools. Use them by name — they are function calls.
 
 ### Waiting
 - `android_wait(text, class_name, timeout_ms=5000)` — poll until an element appears. Use after navigation or loading.
+
+### Microphone
+- `android_mic_record(duration=0)` — start a visible 16 kHz mono recording; `0` records until stopped, with a 30-minute safety cap.
+- `android_mic_stop()` — stop and finalize the WAV.
+- `android_mic_status()` — inspect recorder phase and completed-file metadata.
+- `android_mic_fetch(remote_path="")` — stream the latest or named WAV to a temporary `MEDIA:` file.
 
 ## Rules
 

--- a/tests/test_android_relay.py
+++ b/tests/test_android_relay.py
@@ -15,6 +15,9 @@ from tools.android_relay import (
     _AUTH_MAX_ATTEMPTS,
     _mask_token,
     _safe_body_repr,
+    _decode_stream_frame,
+    _cleanup_phone,
+    _RelayState,
 )
 
 
@@ -96,12 +99,12 @@ class TestTokenMasking:
     def test_normal_token_masked(self):
         token = "SECRET123"
         masked = _mask_token(token)
-        assert masked == "SE****"
+        assert masked == "****"
         assert token not in masked
 
     def test_short_token_fully_masked(self):
         assert _mask_token("X") == "****"
-        assert _mask_token("AB") == "AB****"
+        assert _mask_token("AB") == "****"
 
     def test_empty_token_fully_masked(self):
         assert _mask_token("") == "****"
@@ -177,3 +180,152 @@ class TestWsAuthHeader:
     def test_no_credentials_rejected(self):
         start_relay(pairing_code=self.CODE, port=self.PORT)
         assert not self._try_connect()
+
+
+class TestMicrophoneBinaryStream:
+    PORT = 19882
+    CODE = "MICODE"
+
+    @staticmethod
+    def _frame(request_id: str, payload: bytes) -> bytes:
+        request_id_bytes = request_id.encode("utf-8")
+        return len(request_id_bytes).to_bytes(2, "big") + request_id_bytes + payload
+
+    def test_binary_frame_decoder(self):
+        raw = self._frame("request-1", b"audio")
+        assert _decode_stream_frame(raw) == ("request-1", b"audio")
+
+    @pytest.mark.parametrize("raw", [b"", b"\x00\x00x", b"\x00\x05abc"])
+    def test_binary_frame_decoder_rejects_malformed_frames(self, raw):
+        with pytest.raises(ValueError):
+            _decode_stream_frame(raw)
+
+    def test_replaced_socket_cannot_clean_up_new_phone(self):
+        import asyncio
+
+        async def scenario():
+            state = _RelayState(pairing_code=self.CODE, port=self.PORT)
+            state.phone_ws_lock = asyncio.Lock()
+            old_socket = object()
+            new_socket = object()
+            state.phone_ws = new_socket
+
+            await _cleanup_phone(
+                state,
+                reason="old socket disconnected",
+                expected_ws=old_socket,
+            )
+
+            assert state.phone_ws is new_socket
+
+        asyncio.run(scenario())
+
+    def test_wav_is_streamed_from_phone_to_http_client(self):
+        import asyncio
+        import hashlib
+        import aiohttp
+
+        wav = b"RIFF" + (b"\x01\x02" * 64)
+        start_relay(pairing_code=self.CODE, port=self.PORT)
+
+        async def scenario():
+            headers = {"Authorization": f"Bearer {self.CODE}"}
+            async with aiohttp.ClientSession() as session:
+                ws = await session.ws_connect(
+                    f"ws://127.0.0.1:{self.PORT}/ws",
+                    headers=headers,
+                )
+                download = asyncio.create_task(
+                    session.get(
+                        f"http://127.0.0.1:{self.PORT}/mic_file",
+                        headers=headers,
+                    )
+                )
+
+                command = await ws.receive_json(timeout=2)
+                request_id = command["request_id"]
+                assert command["path"] == "/mic_file"
+
+                await ws.send_json(
+                    {
+                        "request_id": request_id,
+                        "status": 200,
+                        "stream": {
+                            "event": "start",
+                            "filename": "recording_test.wav",
+                            "mimeType": "audio/wav",
+                            "size": len(wav),
+                        },
+                    }
+                )
+                await ws.send_bytes(self._frame(request_id, wav[:48]))
+                await ws.send_bytes(self._frame(request_id, wav[48:]))
+                await ws.send_json(
+                    {
+                        "request_id": request_id,
+                        "status": 200,
+                        "stream": {
+                            "event": "end",
+                            "bytes": len(wav),
+                            "sha256": hashlib.sha256(wav).hexdigest(),
+                        },
+                    }
+                )
+
+                response = await asyncio.wait_for(download, timeout=2)
+                assert response.status == 200
+                assert response.headers["Content-Type"] == "audio/wav"
+                assert await response.read() == wav
+                await ws.close()
+
+        asyncio.run(scenario())
+
+
+class TestPhoneReplacement:
+    PORT = 19883
+    CODE = "REPLCE"
+
+    def test_new_phone_remains_usable_after_replacing_old_socket(self):
+        import asyncio
+        import aiohttp
+
+        start_relay(pairing_code=self.CODE, port=self.PORT)
+
+        async def scenario():
+            headers = {"Authorization": f"Bearer {self.CODE}"}
+            async with aiohttp.ClientSession() as session:
+                old_ws = await session.ws_connect(
+                    f"ws://127.0.0.1:{self.PORT}/ws",
+                    headers=headers,
+                )
+                old_close = asyncio.create_task(old_ws.receive())
+                new_ws = await asyncio.wait_for(
+                    session.ws_connect(
+                        f"ws://127.0.0.1:{self.PORT}/ws",
+                        headers=headers,
+                    ),
+                    timeout=2,
+                )
+                await asyncio.wait_for(old_close, timeout=2)
+
+                request = asyncio.create_task(
+                    session.get(
+                        f"http://127.0.0.1:{self.PORT}/ping",
+                        headers=headers,
+                    )
+                )
+                command = await new_ws.receive_json(timeout=2)
+                await new_ws.send_json(
+                    {
+                        "request_id": command["request_id"],
+                        "status": 200,
+                        "result": {"status": "ok"},
+                    }
+                )
+
+                response = await asyncio.wait_for(request, timeout=2)
+                assert response.status == 200
+                assert await response.json() == {"status": "ok"}
+                await new_ws.close()
+
+        asyncio.run(scenario())

--- a/tests/test_android_tool.py
+++ b/tests/test_android_tool.py
@@ -33,6 +33,10 @@ from tools.android_tool import (
     android_events,
     android_event_stream,
     android_screen_record,
+    android_mic_record,
+    android_mic_stop,
+    android_mic_status,
+    android_mic_fetch,
     android_read_widgets,
     android_media,
     android_search_contacts,
@@ -49,11 +53,11 @@ from tools.android_tool import (
 
 
 class TestSchemas:
-    def test_all_38_tools_have_schemas(self):
-        assert len(_SCHEMAS) == 38
+    def test_all_42_tools_have_schemas(self):
+        assert len(_SCHEMAS) == 42
 
-    def test_all_38_tools_have_handlers(self):
-        assert len(_HANDLERS) == 38
+    def test_all_42_tools_have_handlers(self):
+        assert len(_HANDLERS) == 42
 
     def test_schema_names_match_handler_names(self):
         assert set(_SCHEMAS.keys()) == set(_HANDLERS.keys())
@@ -79,6 +83,18 @@ class TestCodeQuality:
         # These should be present (used functions)
         assert "start_relay" in source
         assert "is_phone_connected" in source
+
+    def test_plugin_copy_registers_all_tools_without_device_specific_values(self):
+        import runpy
+        from pathlib import Path
+
+        plugin_path = Path(__file__).parents[1] / "hermes-android-plugin" / "android_tool.py"
+        plugin_source = plugin_path.read_text(encoding="utf-8")
+        plugin = runpy.run_path(str(plugin_path))
+
+        assert len(plugin["_SCHEMAS"]) == 42
+        assert set(plugin["_SCHEMAS"]) == set(plugin["_HANDLERS"])
+        assert ("scp " + "-P") not in plugin_source
 
 
 class TestPing:
@@ -856,6 +872,68 @@ class TestScreenRecord:
             body=ConnectionError("refused"),
         )
         result = json.loads(android_screen_record())
+        assert "error" in result
+
+
+class TestMicrophone:
+    @responses.activate
+    def test_start_recording(self, bridge_url):
+        responses.add(
+            responses.POST,
+            f"{bridge_url}/mic_start",
+            json={"status": "starting", "duration": 12},
+            status=202,
+        )
+        result = json.loads(android_mic_record(duration=12))
+        assert result == {"status": "starting", "duration": 12}
+        assert json.loads(responses.calls[0].request.body) == {"duration": 12}
+
+    def test_rejects_invalid_duration_without_network_call(self):
+        result = json.loads(android_mic_record(duration=1801))
+        assert "error" in result
+
+    @responses.activate
+    def test_stop_recording(self, bridge_url):
+        responses.add(
+            responses.POST,
+            f"{bridge_url}/mic_stop",
+            json={"status": "stopping"},
+            status=202,
+        )
+        assert json.loads(android_mic_stop())["status"] == "stopping"
+
+    @responses.activate
+    def test_recording_status(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/mic_status",
+            json={"phase": "ready", "recording": False, "latest": "recording_test.wav"},
+        )
+        assert json.loads(android_mic_status())["phase"] == "ready"
+
+    @responses.activate
+    def test_fetch_streams_wav_to_media_path(self, bridge_url):
+        from pathlib import Path
+
+        wav = b"RIFF" + (b"\x00" * 4) + b"WAVE" + (b"\x00" * 52)
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/mic_file",
+            body=wav,
+            status=200,
+            headers={"Content-Type": "audio/wav", "Content-Length": str(len(wav))},
+        )
+
+        result = android_mic_fetch("recording_test.wav")
+        media_path = Path(result.split("MEDIA:", 1)[1])
+        try:
+            assert media_path.read_bytes() == wav
+            assert "name=recording_test.wav" in responses.calls[0].request.url
+        finally:
+            media_path.unlink(missing_ok=True)
+
+    def test_fetch_rejects_device_paths(self):
+        result = json.loads(android_mic_fetch("../recording.wav"))
         assert "error" in result
 
 

--- a/tools/android_relay.py
+++ b/tools/android_relay.py
@@ -24,10 +24,12 @@ Command JSON format:
 # to enable wss:// connections. Without these, the relay uses plaintext http.
 
 import asyncio
+import hashlib
 import hmac
 import json
 import logging
 import os
+import re
 import threading
 import time
 import uuid
@@ -67,6 +69,11 @@ class _RelayState:
         # Pending requests: request_id -> asyncio.Future
         self.pending: dict[str, asyncio.Future] = {}
         self.pending_lock: Optional[asyncio.Lock] = None  # created lazily
+
+        # Binary HTTP responses (currently microphone WAV downloads):
+        # request_id -> bounded queue of ("message"|"chunk"|"error", payload).
+        self.streams: dict[str, asyncio.Queue] = {}
+        self.streams_lock: Optional[asyncio.Lock] = None
 
         # Shutdown event
         self.shutdown_event: Optional[asyncio.Event] = None
@@ -164,6 +171,7 @@ def _run_loop(state: _RelayState, ready: threading.Event) -> None:
     state.loop = loop
     state.phone_ws_lock = asyncio.Lock()
     state.pending_lock = asyncio.Lock()
+    state.streams_lock = asyncio.Lock()
     state.shutdown_event = asyncio.Event()
 
     try:
@@ -196,7 +204,10 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
     state.app = app
 
     # WebSocket endpoint
-    app.router.add_get("/ws", lambda req: _handle_ws(req, state))
+    async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
+        return await _handle_ws(request, state)
+
+    app.router.add_get("/ws", websocket_handler)
 
     # HTTP bridge endpoints — method per path
     ROUTES = {
@@ -212,6 +223,8 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
         "/screen_hash":   "GET",
         "/location":      "GET",
         "/widgets":       "GET",
+        "/mic_status":    "GET",
+        "/mic_file":      "GET",
         # POST-only
         "/tap":           "POST",
         "/tap_text":      "POST",
@@ -236,12 +249,16 @@ async def _serve(state: _RelayState, ready: threading.Event) -> None:
         "/stop_speaking": "POST",
         "/screen_record": "POST",
         "/events/stream": "POST",
+        "/mic_start":     "POST",
+        "/mic_stop":      "POST",
         # READ + WRITE
         "/clipboard":     "BOTH",
     }
 
     for path, method in ROUTES.items():
-        handler = lambda req, p=path: _handle_http(req, state, p)
+        async def handler(request: web.Request, route_path: str = path) -> web.StreamResponse:
+            return await _handle_http(request, state, route_path)
+
         if method in ("GET", "BOTH"):
             app.router.add_get(path, handler)
         if method in ("POST", "BOTH"):
@@ -356,7 +373,8 @@ def _auth_record_failure(ip: str) -> None:
 
 
 def _mask_token(token: str) -> str:
-    return (token[:2] + "****") if len(token) >= 2 else "****"
+    # Never emit even a prefix: the pairing token grants full device control.
+    return "****"
 
 
 # Request-body fields that may carry PII or secrets (phone numbers, SMS text,
@@ -412,6 +430,7 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
     async with state.phone_ws_lock:
         if state.phone_ws is not None and not state.phone_ws.closed:
             logger.info("Replacing previous phone connection")
+            await _fail_inflight(state, reason="phone connection replaced")
             await state.phone_ws.close(
                 code=aiohttp.WSCloseCode.GOING_AWAY, message=b"replaced"
             )
@@ -423,11 +442,13 @@ async def _handle_ws(request: web.Request, state: _RelayState) -> web.WebSocketR
         async for msg in ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
                 await _on_phone_message(state, msg.data)
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                await _on_phone_binary(state, msg.data)
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 logger.error("Phone WS error: %s", ws.exception())
                 break
     finally:
-        await _cleanup_phone(state, reason="phone disconnected")
+        await _cleanup_phone(state, reason="phone disconnected", expected_ws=ws)
 
     return ws
 
@@ -445,6 +466,12 @@ async def _on_phone_message(state: _RelayState, raw: str) -> None:
         logger.warning("Phone message missing request_id: %s", raw[:200])
         return
 
+    async with state.streams_lock:
+        stream_queue = state.streams.get(request_id)
+    if stream_queue is not None:
+        await stream_queue.put(("message", data))
+        return
+
     async with state.pending_lock:
         future = state.pending.pop(request_id, None)
 
@@ -458,15 +485,57 @@ async def _on_phone_message(state: _RelayState, raw: str) -> None:
         future.set_result(data)
 
 
-async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
+def _decode_stream_frame(raw: bytes) -> tuple[str, bytes]:
+    """Decode a binary phone frame: uint16 request-id length, UTF-8 id, payload."""
+    if len(raw) < 3:
+        raise ValueError("Binary stream frame is too short")
+    request_id_length = int.from_bytes(raw[:2], byteorder="big", signed=False)
+    if request_id_length < 1 or request_id_length > 128:
+        raise ValueError("Binary stream frame has an invalid request-id length")
+    payload_offset = 2 + request_id_length
+    if payload_offset > len(raw):
+        raise ValueError("Binary stream frame is truncated")
+    request_id = raw[2:payload_offset].decode("utf-8")
+    return request_id, raw[payload_offset:]
+
+
+async def _on_phone_binary(state: _RelayState, raw: bytes) -> None:
+    try:
+        request_id, payload = _decode_stream_frame(raw)
+    except (UnicodeDecodeError, ValueError) as exc:
+        logger.warning("Invalid binary stream frame from phone: %s", exc)
+        return
+
+    async with state.streams_lock:
+        stream_queue = state.streams.get(request_id)
+    if stream_queue is None:
+        logger.debug("No active stream for request_id=%s", request_id)
+        return
+    await stream_queue.put(("chunk", payload))
+
+
+async def _cleanup_phone(
+    state: _RelayState,
+    reason: str = "",
+    expected_ws: Optional[web.WebSocketResponse] = None,
+) -> None:
     """Clean up phone connection and cancel all pending requests."""
     async with state.phone_ws_lock:
+        # A newly connected phone may already have replaced this socket. The
+        # old handler must not tear down the replacement or its active requests.
+        if expected_ws is not None and state.phone_ws is not expected_ws:
+            return
         ws = state.phone_ws
         state.phone_ws = None
 
     if ws is not None and not ws.closed:
         await ws.close()
 
+    await _fail_inflight(state, reason)
+
+
+async def _fail_inflight(state: _RelayState, reason: str) -> None:
+    """Fail requests that were assigned to a phone connection that is gone."""
     # Fail all pending futures
     async with state.pending_lock:
         pending = dict(state.pending)
@@ -475,6 +544,17 @@ async def _cleanup_phone(state: _RelayState, reason: str = "") -> None:
     for rid, fut in pending.items():
         if not fut.done():
             fut.set_exception(ConnectionError(f"Phone disconnected ({reason})"))
+
+    async with state.streams_lock:
+        stream_queues = list(state.streams.values())
+        state.streams.clear()
+    for queue in stream_queues:
+        while not queue.empty():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        queue.put_nowait(("error", f"Phone disconnected ({reason})"))
 
     if pending:
         logger.info("Cancelled %d pending requests (%s)", len(pending), reason)
@@ -487,7 +567,7 @@ _RESPONSE_TIMEOUT = 30  # seconds
 
 async def _handle_http(
     request: web.Request, state: _RelayState, path: str
-) -> web.Response:
+) -> web.StreamResponse:
     """Forward an HTTP request from a tool to the phone over WebSocket."""
     # ── Auth check ──────────────────────────────────────────────────────────
     # Require Bearer token matching the pairing code.  The client already sends
@@ -543,21 +623,36 @@ async def _handle_http(
     }
     logger.debug(">>> %s %s body=%s", method, path, _safe_body_repr(body))
 
-    # Register a future *before* sending so we never miss the reply
-    future = state.loop.create_future()
-    async with state.pending_lock:
-        state.pending[request_id] = future
+    # Register the response target *before* sending so we never miss a reply.
+    is_binary_stream = path == "/mic_file"
+    future = None
+    stream_queue = None
+    if is_binary_stream:
+        stream_queue = asyncio.Queue(maxsize=8)
+        async with state.streams_lock:
+            state.streams[request_id] = stream_queue
+    else:
+        future = state.loop.create_future()
+        async with state.pending_lock:
+            state.pending[request_id] = future
 
     try:
         await ws.send_json(command)
     except Exception as exc:
-        async with state.pending_lock:
-            state.pending.pop(request_id, None)
+        if is_binary_stream:
+            async with state.streams_lock:
+                state.streams.pop(request_id, None)
+        else:
+            async with state.pending_lock:
+                state.pending.pop(request_id, None)
         logger.error("Failed to send command to phone: %s", exc)
         return web.json_response(
             {"error": f"Failed to send command to phone: {exc}"},
             status=502,
         )
+
+    if is_binary_stream:
+        return await _relay_binary_stream(request, state, request_id, stream_queue)
 
     # Wait for the phone's response
     try:
@@ -582,3 +677,106 @@ async def _handle_http(
     status = response_data.get("status", 200)
     result = response_data.get("result", {})
     return web.json_response(result, status=status)
+
+
+_MAX_STREAM_BYTES = 256 * 1024 * 1024
+
+
+async def _relay_binary_stream(
+    request: web.Request,
+    state: _RelayState,
+    request_id: str,
+    queue: asyncio.Queue,
+) -> web.StreamResponse:
+    """Stream binary phone frames to the authenticated HTTP caller with backpressure."""
+    response = None
+    try:
+        kind, first = await asyncio.wait_for(queue.get(), timeout=_RESPONSE_TIMEOUT)
+        if kind == "error":
+            return web.json_response({"error": first}, status=502)
+        if kind != "message":
+            return web.json_response({"error": "Phone sent stream data before metadata"}, status=502)
+
+        stream = first.get("stream") if isinstance(first, dict) else None
+        if not isinstance(stream, dict) or stream.get("event") != "start":
+            status = first.get("status", 502) if isinstance(first, dict) else 502
+            result = first.get("result", {"error": "Invalid stream response"}) if isinstance(first, dict) else {"error": "Invalid stream response"}
+            return web.json_response(result, status=status)
+
+        expected_size = int(stream.get("size", -1))
+        if expected_size < 0 or expected_size > _MAX_STREAM_BYTES:
+            return web.json_response({"error": "Recording size is invalid"}, status=413)
+
+        raw_filename = os.path.basename(str(stream.get("filename", "recording.wav")))
+        filename = re.sub(r"[^A-Za-z0-9._-]", "_", raw_filename)
+        if not filename.lower().endswith(".wav"):
+            filename = "recording.wav"
+        mime_type = str(stream.get("mimeType", "audio/wav"))
+        if mime_type != "audio/wav":
+            mime_type = "application/octet-stream"
+
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Type": mime_type,
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length": str(expected_size),
+            },
+        )
+        await response.prepare(request)
+
+        digest = hashlib.sha256()
+        total = 0
+        while True:
+            kind, payload = await asyncio.wait_for(queue.get(), timeout=_RESPONSE_TIMEOUT)
+            if kind == "error":
+                raise ConnectionError(str(payload))
+            if kind == "chunk":
+                total += len(payload)
+                if total > expected_size or total > _MAX_STREAM_BYTES:
+                    raise ValueError("Phone sent more recording data than declared")
+                digest.update(payload)
+                await response.write(payload)
+                continue
+            if kind != "message":
+                raise ValueError("Unknown stream event")
+
+            stream_event = payload.get("stream") if isinstance(payload, dict) else None
+            event_name = stream_event.get("event") if isinstance(stream_event, dict) else None
+            if event_name == "error":
+                raise IOError(str(stream_event.get("message", "Phone stream failed")))
+            if event_name != "end":
+                raise ValueError("Invalid stream completion event")
+            if total != expected_size or int(stream_event.get("bytes", -1)) != total:
+                raise IOError("Recording stream length does not match metadata")
+            expected_sha = str(stream_event.get("sha256", ""))
+            if not re.fullmatch(r"[0-9a-f]{64}", expected_sha) or not hmac.compare_digest(
+                digest.hexdigest(), expected_sha
+            ):
+                raise IOError("Recording stream checksum mismatch")
+            await response.write_eof()
+            return response
+    except asyncio.TimeoutError:
+        logger.warning("Timed out receiving microphone stream request_id=%s", request_id)
+        if response is None:
+            return web.json_response({"error": "Phone stream timed out"}, status=504)
+        response.force_close()
+        return response
+    except Exception as exc:
+        logger.warning("Microphone stream failed request_id=%s: %s", request_id, exc)
+        if response is None:
+            return web.json_response({"error": "Phone stream failed"}, status=502)
+        response.force_close()
+        return response
+    finally:
+        async with state.streams_lock:
+            if state.streams.get(request_id) is queue:
+                state.streams.pop(request_id, None)
+        # If the HTTP consumer disappeared while the bounded queue was full,
+        # free any waiting WebSocket producer immediately.
+        while not queue.empty():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break

--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -36,6 +36,10 @@ Tools registered:
   - android_events           read recent accessibility events
   - android_event_stream     enable/disable event capture
   - android_screen_record    record screen to video
+  - android_mic_record       start microphone WAV recording
+  - android_mic_stop         stop and finalize microphone recording
+  - android_mic_status       inspect microphone recorder state
+  - android_mic_fetch        stream a WAV to a local MEDIA file
   - android_read_widgets     read home-screen widgets
   - android_find_nodes       search UI nodes by text/class/clickable
   - android_diff_screen      diff screen against a previous hash
@@ -629,6 +633,97 @@ def android_screen_record(duration_ms: int = 5000) -> str:
                 return f"Screen recorded ({w}x{h}, {duration_ms}ms)\nMEDIA:{tmp.name}"
         return json.dumps(data)
     except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_mic_record(duration: int = 0) -> str:
+    """Start PCM16/WAV recording; duration=0 records until stopped (30-minute cap)."""
+    if isinstance(duration, bool) or not isinstance(duration, int) or duration < 0 or duration > 1800:
+        return json.dumps({"error": "duration must be between 0 and 1800 seconds"})
+    try:
+        return json.dumps(_post("/mic_start", {"duration": duration}))
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_mic_stop() -> str:
+    """Stop the active microphone recording and finalize its WAV file."""
+    try:
+        return json.dumps(_post("/mic_stop", {}))
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_mic_status() -> str:
+    """Return recorder phase plus metadata for the latest completed WAV."""
+    try:
+        return json.dumps(_get("/mic_status"))
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def android_mic_fetch(remote_path: str = "") -> str:
+    """Stream the latest (or named) WAV to a temporary local MEDIA path."""
+    if not isinstance(remote_path, str):
+        return json.dumps({"error": "remote_path must be a WAV filename"})
+    if remote_path and (
+        os.path.basename(remote_path) != remote_path
+        or not remote_path.lower().endswith(".wav")
+    ):
+        return json.dumps({"error": "remote_path must be a WAV filename, not a path"})
+
+    import tempfile
+
+    temp_path = None
+    try:
+        params = {"name": remote_path} if remote_path else None
+        with requests.get(
+            f"{_bridge_url()}/mic_file",
+            params=params,
+            headers=_auth_headers(),
+            timeout=_timeout(),
+            stream=True,
+        ) as response:
+            if response.status_code >= 400:
+                try:
+                    return json.dumps(response.json())
+                except ValueError:
+                    return json.dumps({"error": f"Microphone download failed (HTTP {response.status_code})"})
+
+            expected = response.headers.get("Content-Length")
+            expected_size = int(expected) if expected and expected.isdigit() else None
+            if expected_size is not None and expected_size > 256 * 1024 * 1024:
+                return json.dumps({"error": "Microphone recording exceeds the download limit"})
+
+            written = 0
+            prefix = bytearray()
+            with tempfile.NamedTemporaryFile(
+                suffix=".wav",
+                prefix="android_mic_",
+                delete=False,
+            ) as output:
+                temp_path = output.name
+                for chunk in response.iter_content(chunk_size=64 * 1024):
+                    if not chunk:
+                        continue
+                    written += len(chunk)
+                    if written > 256 * 1024 * 1024:
+                        raise ValueError("Microphone recording exceeds the download limit")
+                    if len(prefix) < 12:
+                        prefix.extend(chunk[: 12 - len(prefix)])
+                    output.write(chunk)
+
+        if expected_size is not None and written != expected_size:
+            raise IOError("Microphone recording download was incomplete")
+        if len(prefix) < 12 or prefix[:4] != b"RIFF" or prefix[8:12] != b"WAVE":
+            raise IOError("Downloaded microphone recording is not a WAV file")
+        return f"Microphone recording fetched ({written} bytes)\nMEDIA:{temp_path}"
+    except Exception as e:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
         return json.dumps({"error": str(e)})
 
 
@@ -1319,6 +1414,49 @@ _SCHEMAS = {
             "required": [],
         },
     },
+    "android_mic_record": {
+        "name": "android_mic_record",
+        "description": "Start a 16 kHz mono WAV microphone recording on the Android device.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "duration": {
+                    "type": "integer",
+                    "description": "Seconds to record (0 records until android_mic_stop, capped at 1800; maximum 1800)",
+                    "minimum": 0,
+                    "maximum": 1800,
+                    "default": 0,
+                },
+            },
+            "required": [],
+        },
+    },
+    "android_mic_stop": {
+        "name": "android_mic_stop",
+        "description": "Stop the active microphone recording and finalize its WAV file.",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_mic_status": {
+        "name": "android_mic_status",
+        "description": "Get microphone recorder state and latest completed WAV metadata.",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    "android_mic_fetch": {
+        "name": "android_mic_fetch",
+        "description": "Download the latest or named microphone WAV as a local MEDIA file.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "remote_path": {
+                    "type": "string",
+                    "description": "Optional WAV filename returned by android_mic_status; paths are rejected",
+                    "default": "",
+                },
+            },
+            "required": [],
+        },
+    },
+
     "android_read_widgets": {
         "name": "android_read_widgets",
         "description": "Read home screen widgets (weather, calendar, tasks, etc.). Goes to home screen and reads widget content without opening apps.",
@@ -1497,6 +1635,10 @@ _HANDLERS = {
     "android_events": lambda args, **kw: android_events(**args),
     "android_event_stream": lambda args, **kw: android_event_stream(**args),
     "android_screen_record": lambda args, **kw: android_screen_record(**args),
+    "android_mic_record": lambda args, **kw: android_mic_record(**args),
+    "android_mic_stop": lambda args, **kw: android_mic_stop(),
+    "android_mic_status": lambda args, **kw: android_mic_status(),
+    "android_mic_fetch": lambda args, **kw: android_mic_fetch(**args),
     "android_read_widgets": lambda args, **kw: android_read_widgets(),
     "android_find_nodes": lambda args, **kw: android_find_nodes(**args),
     "android_diff_screen": lambda args, **kw: android_diff_screen(**args),


### PR DESCRIPTION
## What
Adds microphone recording to the Hermes Bridge app — the foundation for ambient sound analysis and voice capture (Roadmap v0.5 "Voice assistant mode").

## Changes
- **Android (Kotlin):**
  - `MicrophoneRecorderService.kt` — Foreground Service with `foregroundServiceType="microphone"` (Android 14+ required for continuous mic), uses `AudioRecord` → writes WAV (16 kHz, mono, PCM16)
  - Manifest: `RECORD_AUDIO` + `FOREGROUND_SERVICE_MICROPHONE`
  - New bridge routes: `POST /mic_start` (duration optional), `POST /mic_stop`, `GET /mic_status`
- **Python toolset:** 4 new tools — `android_mic_record`, `android_mic_stop`, `android_mic_status`, `android_mic_fetch`

## Why
The phone's microphone is the last missing sensor for a fully autonomous edge device. Phase 1 records stable PCM/WAV via the supported Android path (no shell hacks). Subsequent phases: VAD, then STT (Whisper/Vosk), then wake word — exactly as planned in the roadmap.

## Testing
- `AudioRecord` initialized at 16kHz mono on Pixel 6 Pro (Android 14)
- WAV header written correctly (44-byte RIFF, sizes patched on stop)
- Foreground service notification shown while recording

## Notes
- Records to app-specific external dir (`cradata_audio/`) — no storage permission needed
- Start: `POST /mic_start {"duration": 10}` (0 = until stop)
- Files retrieved via SCP/ADB or a future file-transfer endpoint