### PR TITLE
fix: .env token fallback + wake key (not power dialog)

### DIFF
--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/executor/ActionExecutor.kt
@@ -175,6 +175,15 @@ object ActionExecutor {
     fun pressKey(key: String): ActionResult {
         val service = BridgeAccessibilityService.instance
             ?: return ActionResult(false, "Accessibility service not running")
+
+        // "wake" turns the screen on (short press) — NOT the power dialog.
+        // GLOBAL_ACTION_POWER_DIALOG is the long-press menu (reboot/emergency),
+        // which is almost never what a caller wants when waking the device.
+        if (key == "wake") {
+            val woke = WakeLockManager.wake()
+            return ActionResult(woke, if (woke) "Woke screen" else "Wake failed (PowerManager unavailable)")
+        }
+
         val action = when (key) {
             "back" -> AccessibilityService.GLOBAL_ACTION_BACK
             "home" -> AccessibilityService.GLOBAL_ACTION_HOME

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/power/WakeLockManager.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/power/WakeLockManager.kt
@@ -14,6 +14,14 @@ object WakeLockManager {
         powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
     }
 
+    /** Turn the screen on (short "wake" press). Returns true on success. */
+    fun wake(): Boolean {
+        val pm = powerManager ?: return false
+        if (pm.isInteractive) return true
+        acquireWakeLock()
+        return true
+    }
+
     suspend fun <T> wakeForAction(block: suspend () -> T): T {
         val pm = powerManager
         val alreadyAwake = pm?.isInteractive ?: true

--- a/hermes-android-plugin/android_tool.py
+++ b/hermes-android-plugin/android_tool.py
@@ -27,13 +27,52 @@ from urllib.parse import quote
 # by setting ANDROID_BRIDGE_URL to the phone's IP.
 
 
+_ENV_FILE_CACHE: Optional[dict] = None
+
+
+def _env_file_vars() -> dict:
+    """Parse ~/.hermes/.env once, cached.
+
+    The gateway process does not always export every .env var into os.environ
+    (it loads .env for its own config but the plugin runs in a context where
+    ANDROID_BRIDGE_TOKEN may be missing).  Fall back to reading the file
+    directly so auth works regardless of how the process was started.
+    """
+    global _ENV_FILE_CACHE
+    if _ENV_FILE_CACHE is not None:
+        return _ENV_FILE_CACHE
+    _ENV_FILE_CACHE = {}
+    env_path = os.path.join(
+        os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), ".env"
+    )
+    try:
+        with open(env_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                _ENV_FILE_CACHE[key.strip()] = value.strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return _ENV_FILE_CACHE
+
+
+def _env(key: str) -> Optional[str]:
+    """os.environ first, then ~/.hermes/.env as a fallback."""
+    val = os.getenv(key)
+    if val:
+        return val
+    return _env_file_vars().get(key)
+
+
 def _bridge_url() -> str:
     """URL of the relay (default) or direct phone connection."""
-    return os.getenv("ANDROID_BRIDGE_URL", "http://localhost:8766")
+    return _env("ANDROID_BRIDGE_URL") or "http://localhost:8766"
 
 
 def _bridge_token() -> Optional[str]:
-    return os.getenv("ANDROID_BRIDGE_TOKEN")
+    return _env("ANDROID_BRIDGE_TOKEN")
 
 
 def _relay_port() -> int:
@@ -211,7 +250,8 @@ def android_press_key(key: str) -> str:
     """
     Press a key. Supported keys:
       back, home, recents, power, notifications,
-      quick_settings, lock_screen, take_screenshot
+      quick_settings, lock_screen, take_screenshot, wake
+    (wake = turn the screen on; power = long-press power menu)
     """
     try:
         data = _post("/press_key", {"key": key})
@@ -1064,6 +1104,7 @@ _SCHEMAS = {
                         "quick_settings",
                         "lock_screen",
                         "take_screenshot",
+                        "wake",
                     ],
                 }
             },

--- a/tests/test_android_tool.py
+++ b/tests/test_android_tool.py
@@ -379,6 +379,47 @@ class TestSetup:
         assert "localhost" in os.environ.get("ANDROID_BRIDGE_URL", "")
 
 
+class TestEnvFileFallback:
+    """The gateway process may lack ANDROID_* vars in os.environ even though
+    they exist in ~/.hermes/.env.  _bridge_token/_bridge_url must fall back to
+    reading the .env file so the relay still authenticates."""
+
+    def test_token_from_env_file_when_os_environ_empty(self, monkeypatch, tmp_path):
+        from tools import android_tool
+
+        monkeypatch.delenv("ANDROID_BRIDGE_TOKEN", raising=False)
+        monkeypatch.delenv("ANDROID_BRIDGE_URL", raising=False)
+        monkeypatch.setattr(android_tool, "_ENV_FILE_CACHE", None)
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("ANDROID_BRIDGE_TOKEN=SECRET123\nANDROID_BRIDGE_URL=http://1.2.3.4:8766\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert android_tool._bridge_token() == "SECRET123"
+        assert android_tool._bridge_url() == "http://1.2.3.4:8766"
+
+    def test_os_environ_wins_over_env_file(self, monkeypatch, tmp_path):
+        from tools import android_tool
+
+        monkeypatch.setenv("ANDROID_BRIDGE_TOKEN", "FROM_ENV")
+        monkeypatch.setattr(android_tool, "_ENV_FILE_CACHE", None)
+        env_file = tmp_path / ".env"
+        env_file.write_text("ANDROID_BRIDGE_TOKEN=FROM_FILE\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert android_tool._bridge_token() == "FROM_ENV"
+
+    def test_missing_env_file_returns_none(self, monkeypatch, tmp_path):
+        from tools import android_tool
+
+        monkeypatch.delenv("ANDROID_BRIDGE_TOKEN", raising=False)
+        monkeypatch.setattr(android_tool, "_ENV_FILE_CACHE", None)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nonexistent"))
+
+        assert android_tool._bridge_token() is None
+        assert android_tool._bridge_url() == "http://localhost:8766"
+
+
 class TestClipboardRead:
     @responses.activate
     def test_clipboard_read(self, bridge_url):

--- a/tools/android_tool.py
+++ b/tools/android_tool.py
@@ -68,13 +68,52 @@ from urllib.parse import quote
 # by setting ANDROID_BRIDGE_URL to the phone's IP.
 
 
+_ENV_FILE_CACHE: Optional[dict] = None
+
+
+def _env_file_vars() -> dict:
+    """Parse ~/.hermes/.env once, cached.
+
+    The gateway process does not always export every .env var into os.environ
+    (it loads .env for its own config but the plugin runs in a context where
+    ANDROID_BRIDGE_TOKEN may be missing).  Fall back to reading the file
+    directly so auth works regardless of how the process was started.
+    """
+    global _ENV_FILE_CACHE
+    if _ENV_FILE_CACHE is not None:
+        return _ENV_FILE_CACHE
+    _ENV_FILE_CACHE = {}
+    env_path = os.path.join(
+        os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), ".env"
+    )
+    try:
+        with open(env_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                _ENV_FILE_CACHE[key.strip()] = value.strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return _ENV_FILE_CACHE
+
+
+def _env(key: str) -> Optional[str]:
+    """os.environ first, then ~/.hermes/.env as a fallback."""
+    val = os.getenv(key)
+    if val:
+        return val
+    return _env_file_vars().get(key)
+
+
 def _bridge_url() -> str:
     """URL of the relay (default) or direct phone connection."""
-    return os.getenv("ANDROID_BRIDGE_URL", "http://localhost:8766")
+    return _env("ANDROID_BRIDGE_URL") or "http://localhost:8766"
 
 
 def _bridge_token() -> Optional[str]:
-    return os.getenv("ANDROID_BRIDGE_TOKEN")
+    return _env("ANDROID_BRIDGE_TOKEN")
 
 
 def _relay_port() -> int:
@@ -252,7 +291,8 @@ def android_press_key(key: str) -> str:
     """
     Press a key. Supported keys:
       back, home, recents, power, notifications,
-      quick_settings, lock_screen, take_screenshot
+      quick_settings, lock_screen, take_screenshot, wake
+    (wake = turn the screen on; power = long-press power menu)
     """
     try:
         data = _post("/press_key", {"key": key})
@@ -1108,6 +1148,7 @@ _SCHEMAS = {
                         "quick_settings",
                         "lock_screen",
                         "take_screenshot",
+                        "wake",
                     ],
                 }
             },


### PR DESCRIPTION
Two fixes from live debugging of the phone bridge:

## 1. Bridge token fallback (critical)

The gateway process does not always export `ANDROID_BRIDGE_TOKEN` into `os.environ`, so `_check_requirements()` sent no Authorization header, `/ping` returned 401, and all 13 gated `android_*` tools failed their check and vanished — every call errored with `'android_ping' is not available in this session`.

**Fix:** `_env_file_vars()` (cached parse of `~/.hermes/.env`) + `_env()` (os.environ first, .env fallback). `_bridge_url`/`_bridge_token` go through it. Applied to both `tools/android_tool.py` and `hermes-android-plugin/android_tool.py` (kept in sync per the file header). 3 regression tests added.

## 2. 'wake' key (bridge app)

`pressKey("power")` mapped to `GLOBAL_ACTION_POWER_DIALOG`, opening the long-press reboot/emergency menu instead of waking the device. Added a dedicated `wake` key that turns the screen on via a short wake-lock, keeping `power` as the explicit power dialog.

- `WakeLockManager.wake()` — acquire screen-bright wake lock if screen is off.
- `ActionExecutor.pressKey()` — handle `wake` before the global-action map.
- Python schema + docstring in both copies add `wake`.

## Verification

- `pytest tests/` — 148 passed (145 existing + 3 new)
- Kotlin changes are minimal and additive; not compiled here (no Gradle on this box), so please let CI build the APK.