### PR TITLE
feat(bridge): add GET /battery endpoint (system battery percentage)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ Required permissions: `ACCESSIBILITY_SERVICE`, `SYSTEM_ALERT_WINDOW`, `INTERNET`
 aiohttp server in a background daemon thread, started by `android_setup()`.
 
 - `/ws` (WebSocket) — phone connects with a Bearer authorization header.
-- HTTP bridge endpoints (method per path) — GET: `/ping`, `/screen`, `/screenshot`, `/apps`, `/current_app`, `/notifications`, `/contacts`, `/events`, `/screen_hash`, `/location`, `/widgets`, `/mic_status`, `/mic_file`. POST: `/tap`, `/tap_text`, `/type`, `/swipe`, `/open_app`, `/press_key`, `/scroll`, `/wait`, `/long_press`, `/drag`, `/describe_node`, `/find_nodes`, `/diff_screen`, `/pinch`, `/send_sms`, `/call`, `/media`, `/intent`, `/broadcast`, `/speak`, `/stop_speaking`, `/screen_record`, `/events/stream`, `/mic_start`, `/mic_stop`. Both: `/clipboard`.
+- HTTP bridge endpoints (method per path) — GET: `/ping`, `/screen`, `/screenshot`, `/apps`, `/current_app`, `/notifications`, `/contacts`, `/events`, `/screen_hash`, `/location`, `/battery`, `/widgets`, `/mic_status`, `/mic_file`. POST: `/tap`, `/tap_text`, `/type`, `/swipe`, `/open_app`, `/press_key`, `/scroll`, `/wait`, `/long_press`, `/drag`, `/describe_node`, `/find_nodes`, `/diff_screen`, `/pinch`, `/send_sms`, `/call`, `/media`, `/intent`, `/broadcast`, `/speak`, `/stop_speaking`, `/screen_record`, `/events/stream`, `/mic_start`, `/mic_stop`. Both: `/clipboard`.
 - Auth: pairing code case-sensitive (exact compare, see #43). 5 failed attempts / 60s → IP blocked 5 min. Only one phone connected at a time.
 
 ## Tools

--- a/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
+++ b/hermes-android-bridge/app/src/main/kotlin/com/hermesandroid/bridge/server/CommandDispatcher.kt
@@ -160,6 +160,25 @@ object CommandDispatcher {
                 result to 200
             }
 
+            method == "GET" && path == "/battery" -> {
+                // Language-independent battery level: AccessibilityService.getBatteryPercentage()
+                // (API 31+) returns the system value directly — no status-bar text parsing.
+                // OEM text formats differ by language and skin ("电量剩余 53。",
+                // "電池電量為百分之 87。", "87%", ...) and any sample-based parser mis-reads.
+                val service = BridgeAccessibilityService.instance
+                    ?: return mapOf("error" to "Accessibility service not running") to 503
+                if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S) {
+                    return mapOf("error" to "Requires Android 12 (API 31)") to 501
+                }
+                val result = mutableMapOf<String, Any>("batteryPercentage" to service.batteryPercentage)
+                // chargerConnected needs ConfigurationConstants (API 33+)
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                    result["chargerConnected"] =
+                        service.resources.configuration.constants?.chargerConnected ?: false
+                }
+                result to 200
+            }
+
             method == "GET" && path == "/clipboard" -> {
                 val result = ActionExecutor.clipboardRead()
                 result to 200

--- a/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/server/CommandDispatcherBatteryTest.kt
+++ b/hermes-android-bridge/app/src/test/kotlin/com/hermesandroid/bridge/server/CommandDispatcherBatteryTest.kt
@@ -1,0 +1,87 @@
+package com.hermesandroid.bridge.server
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.res.Configuration
+import android.os.Build
+import com.google.gson.JsonObject
+import com.hermesandroid.bridge.service.BridgeAccessibilityService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Contract tests for the GET /battery endpoint.
+ *
+ * Battery level must come from AccessibilityService.getBatteryPercentage() (API 30+),
+ * NOT from parsing status-bar text — OEM text formats differ by language and skin
+ * ("电量剩余 53。", "電池電量為百分之 87。", "87%", …) and any parser built from
+ * samples will eventually mis-read. These tests pin that contract: the endpoint
+ * returns the system percentage verbatim with no auth requirement, and reports a
+ * clean error when the accessibility service is absent.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class CommandDispatcherBatteryTest {
+
+    private lateinit var mockService: BridgeAccessibilityService
+
+    @Before
+    fun setup() {
+        mockService = mockk(relaxed = true)
+        mockkObject(BridgeAccessibilityService.Companion)
+        every { BridgeAccessibilityService.instance } returns mockService
+        val config = mockk<Configuration>()
+        val info = mockk<AccessibilityServiceInfo>(relaxed = true)
+        every { mockService.batteryPercentage } returns 87
+        every { mockService.resources.configuration } returns config
+        every { config.constants } returns info
+        every { info.chargerConnected } returns true
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `battery returns the system percentage without authentication`() = runTest {
+        val (result, status) = CommandDispatcher.dispatch("GET", "/battery", JsonObject(), JsonObject(), false)
+
+        assertEquals(200, status)
+        val map = result as Map<*, *>
+        assertEquals(87, map["batteryPercentage"])
+        assertEquals(true, map["chargerConnected"])
+    }
+
+    @Test
+    fun `battery reports 503 when the accessibility service is not running`() = runTest {
+        every { BridgeAccessibilityService.instance } returns null
+
+        val (result, status) = CommandDispatcher.dispatch("GET", "/battery", JsonObject(), JsonObject(), true)
+
+        assertEquals(503, status)
+        val map = result as Map<*, *>
+        assertEquals("Accessibility service not running", map["error"])
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `battery reports 501 on pre-Android-12 devices`() = runTest {
+        assertEquals(30, Build.VERSION.SDK_INT)
+
+        val (result, status) = CommandDispatcher.dispatch("GET", "/battery", JsonObject(), JsonObject(), true)
+
+        assertEquals(501, status)
+        val map = result as Map<*, *>
+        assertEquals("Requires Android 12 (API 31)", map["error"])
+    }
+}


### PR DESCRIPTION
## Why

Servers that drive the bridge currently have to scrape the battery level out of the `/screen` accessibility tree, because there is no battery endpoint. That is fragile: OEM status-bar text varies by skin **and device language** — real samples collected from field devices:

| Device | contentDescription | % sign? |
|---|---|---|
| Honor | `电量剩余 53。` | no |
| Xiaomi (zh-TW locale) | `電池電量為百分之 87。` | no (space after 百分之!) |
| Stock-ish | `87%` / `Battery 87%` | yes |

Any regex built from a few samples eventually mis-reads — we just had a device where an unrelated `8%` label in the tree overwrote the real 87% level.

`AccessibilityService.getBatteryPercentage()` (API 31+) already returns the system value as an int, and `ConfigurationConstants.chargerConnected` (API 33+) adds the charging state. Exposing them costs ~15 lines and removes an entire class of parsing bugs for every server-side consumer.

## What

- `CommandDispatcher`: new `GET /battery` → `{"batteryPercentage": 87, "chargerConnected": true}` (chargerConnected only on API 33+). `503` when the accessibility service isn't running, `501` below API 31. Follows the existing `/current_app` pattern (same dispatcher `when` table, no shared state, works over both transports — relay WS and local HTTP — since routing lives in one place).
- `CommandDispatcherBatteryTest`: Robolectric + mockk contract tests (value verbatim, works unauthenticated, 503/501 error paths) — mirrors the style of `ActionExecutorPressKeyTest` from #101.
- `docs/architecture.md`: endpoint list updated.

## Testing

- Unit tests included (run with `./gradlew test` in `hermes-android-bridge/`).
- Endpoint is read-only, adds no permissions, and touches no existing code path.
